### PR TITLE
fix: editor pagination shows correct row range on non-first pages

### DIFF
--- a/web/src/pages/editor/ResultTable.tsx
+++ b/web/src/pages/editor/ResultTable.tsx
@@ -241,7 +241,7 @@ export function ResultTable({ result, pageSize, resultPage, pageLoading, setResu
           {showPagination && (
             <div className="mt-2 flex items-center justify-end gap-2 text-xs text-[var(--color-text-secondary)]">
               <span>
-                {resultPage * pageSize + 1}-{Math.min((resultPage + 1) * pageSize, totalKnown ? totalRows : result.rows.length)}
+                {resultPage * pageSize + 1}-{totalKnown ? Math.min((resultPage + 1) * pageSize, totalRows) : resultPage * pageSize + result.rows.length}
                 {totalKnown ? ` of ${formatNumber(totalRows)}` : ""}
               </span>
               {pageLoading && <Loader2 className="h-3 w-3 animate-spin" />}


### PR DESCRIPTION
When total_rows is unknown (non-SELECT or count failed), the end of the range used Math.min((page+1)*pageSize, rows.length) which clamped to rows.length (100) regardless of page — producing '101-100' on page 2. Now computes page*pageSize + rows.length for the unknown total case.