### PR TITLE
fix: editor pagination shows correct row range on non-first pages

### DIFF
--- a/web/src/pages/editor/ResultTable.tsx
+++ b/web/src/pages/editor/ResultTable.tsx
@@ -241,7 +241,7 @@ export function ResultTable({ result, pageSize, resultPage, pageLoading, setResu
           {showPagination && (
             <div className="mt-2 flex items-center justify-end gap-2 text-xs text-[var(--color-text-secondary)]">
               <span>
-                {resultPage * pageSize + 1}-{Math.min((resultPage + 1) * pageSize, totalKnown ? totalRows : result.rows.length)}
+                {resultPage * pageSize + 1}-{totalKnown ? Math.min((resultPage + 1) * pageSize, totalRows) : resultPage * pageSize + result.rows.length}
                 {totalKnown ? ` of ${formatNumber(totalRows)}` : ""}
               </span>
               {pageLoading && <Loader2 className="h-3 w-3 animate-spin" />}


### PR DESCRIPTION
When `total_rows` is unknown (non-SELECT query or count query failed), the pagination footer used `Math.min((page+1)*pageSize, rows.length)` for the end of the range. Since `rows.length` is always the current page size (e.g. 100), this clamped to 100 on every page — producing `101-100` on page 2, `201-100` on page 3, etc.

**Fix:** when total is unknown, compute `page * pageSize + rows.length` for the end position.

| Page | Before | After |
|------|--------|-------|
| 1    | 1-100  | 1-100 |
| 2    | 101-**100** | 101-**200** |
| 3    | 201-**100** | 201-**300** |