### PR TITLE
feat: filter ClickLens's own queries from Queries and Fingerprints pages

### DIFF
--- a/internal/clickhouse/client.go
+++ b/internal/clickhouse/client.go
@@ -21,6 +21,13 @@ const (
 	maxPoolSize    = 50
 	connMaxAge     = 1 * time.Hour
 	healthCheckInt = 30 * time.Second
+
+	// managedLogComment is stamped into the log_comment setting of every query
+	// ClickLens issues itself (introspection, health checks, etc.). It lets the
+	// Queries and Fingerprints pages filter out ClickLens's own queries so the
+	// user only sees the queries they consciously executed. User-submitted SQL
+	// from the Query Editor bypasses the driver and is therefore not tagged.
+	managedLogComment = "clicklens"
 )
 
 type Client struct {
@@ -161,41 +168,22 @@ func (p *Pool) getDialMutex(key string) *sync.Mutex {
 	return m
 }
 
-func (p *Pool) connect(ctx context.Context, params ConnParams, key string) (*Client, error) {
-	dialMu := p.getDialMutex(key)
-	dialMu.Lock()
-	defer dialMu.Unlock()
-
-	p.mu.RLock()
-	c, ok := p.clients[key]
-	p.mu.RUnlock()
-	if ok {
-		if time.Since(c.createdAt) < connMaxAge {
-			c.lastUsedAt = time.Now()
-			return c, nil
-		}
-		p.evict(key, c)
-	}
-
-	parsedURL, err := url.Parse(params.URL)
-	if err != nil {
-		return nil, fmt.Errorf("parsing clickhouse URL: %w", err)
-	}
-
+// buildOptions translates connection parameters into clickhouse-go driver
+// options. It is split out of connect() so the connection-level settings
+// (notably the log_comment tag that identifies ClickLens's own queries) can be
+// unit-tested without dialing a real server.
+func buildOptions(parsedURL *url.URL, params ConnParams) *ch.Options {
 	scheme := strings.ToLower(parsedURL.Scheme)
 	useTLS := isTLSScheme(scheme)
 
 	var opts *ch.Options
-
 	if isHTTPScheme(scheme) {
 		opts = &ch.Options{
 			Protocol:    ch.HTTP,
 			Addr:        []string{parsedURL.Host},
 			Auth:        ch.Auth{Username: params.User, Password: params.Password, Database: params.Database},
 			DialTimeout: time.Second * 10,
-		}
-		if useTLS {
-			opts.TLS = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: params.SkipTLS}
+			Settings:    ch.Settings{"log_comment": managedLogComment},
 		}
 	} else {
 		host := parsedURL.Hostname()
@@ -219,11 +207,39 @@ func (p *Pool) connect(ctx context.Context, params ConnParams, key string) (*Cli
 			ConnMaxLifetime:  time.Hour,
 			ConnOpenStrategy: ch.ConnOpenInOrder,
 			BlockBufferSize:  10,
-		}
-		if useTLS {
-			opts.TLS = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: params.SkipTLS}
+			Settings:         ch.Settings{"log_comment": managedLogComment},
 		}
 	}
+
+	if useTLS {
+		opts.TLS = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: params.SkipTLS}
+	}
+	return opts
+}
+
+func (p *Pool) connect(ctx context.Context, params ConnParams, key string) (*Client, error) {
+	dialMu := p.getDialMutex(key)
+	dialMu.Lock()
+	defer dialMu.Unlock()
+
+	p.mu.RLock()
+	c, ok := p.clients[key]
+	p.mu.RUnlock()
+	if ok {
+		if time.Since(c.createdAt) < connMaxAge {
+			c.lastUsedAt = time.Now()
+			return c, nil
+		}
+		p.evict(key, c)
+	}
+
+	parsedURL, err := url.Parse(params.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing clickhouse URL: %w", err)
+	}
+
+	scheme := strings.ToLower(parsedURL.Scheme)
+	opts := buildOptions(parsedURL, params)
 
 	conn, err := ch.Open(opts)
 	if err != nil {

--- a/internal/clickhouse/client_test.go
+++ b/internal/clickhouse/client_test.go
@@ -1,6 +1,11 @@
 package clickhouse
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+
+	ch "github.com/ClickHouse/clickhouse-go/v2"
+)
 
 func TestIsHTTPScheme(t *testing.T) {
 	tests := []struct {
@@ -139,6 +144,53 @@ func TestClient_TableRef(t *testing.T) {
 			c := &Client{isCluster: tt.cluster, cluster: tt.clusterName}
 			if got := c.tableRef(tt.table); got != tt.expected {
 				t.Errorf("tableRef() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestManagedLogComment(t *testing.T) {
+	if managedLogComment != "clicklens" {
+		t.Errorf("managedLogComment = %q, want %q", managedLogComment, "clicklens")
+	}
+}
+
+func TestBuildOptions_TagsManagedQueries(t *testing.T) {
+	params := ConnParams{
+		URL:      "clickhouse://host:9000",
+		User:     "default",
+		Password: "secret",
+		Database: "system",
+	}
+
+	cases := []struct {
+		name     string
+		url      string
+		protocol ch.Protocol
+	}{
+		{"native", "clickhouse://host:9000", ch.Native},
+		{"native tls", "clickhouses://host:9440", ch.Native},
+		{"http", "http://host:8123", ch.HTTP},
+		{"https", "https://host:8443", ch.HTTP},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params.URL = tc.url
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("parsing url: %v", err)
+			}
+			opts := buildOptions(u, params)
+			if opts.Protocol != tc.protocol {
+				t.Errorf("protocol = %v, want %v", opts.Protocol, tc.protocol)
+			}
+			v, ok := opts.Settings["log_comment"]
+			if !ok {
+				t.Fatal("expected log_comment setting on connection options")
+			}
+			if v != managedLogComment {
+				t.Errorf("log_comment = %v, want %q", v, managedLogComment)
 			}
 		})
 	}

--- a/internal/clickhouse/query_log.go
+++ b/internal/clickhouse/query_log.go
@@ -65,6 +65,15 @@ var defaultListParams = QueryListParams{
 	SortDir: "DESC",
 }
 
+// hideSystemQueriesClause returns the SQL fragment used to suppress non-user
+// queries when "Hide system queries" is enabled. It excludes noise query kinds
+// (DDL, EXPLAIN, etc.) as well as queries ClickLens issued itself, which are
+// tagged via the log_comment setting so the user only sees the queries they
+// consciously executed.
+func hideSystemQueriesClause() string {
+	return "NOT has(databases, 'system') AND lower(query_kind) NOT IN ('explain', 'system', 'show', 'create', 'drop', 'alter', 'set', 'use', 'kill', 'optimize', 'truncate', 'rename', 'check', 'detach', 'attach', 'none') AND log_comment != '" + managedLogComment + "'"
+}
+
 func (c *Client) ListQueries(ctx context.Context, params QueryListParams) ([]QueryLogEntry, uint64, error) {
 	if params.Limit <= 0 {
 		params.Limit = defaultListParams.Limit
@@ -112,7 +121,7 @@ func (c *Client) ListQueries(ctx context.Context, params QueryListParams) ([]Que
 	whereArgs := []interface{}{}
 
 	if params.HideSystemQueries {
-		whereParts = append(whereParts, "NOT has(databases, 'system') AND lower(query_kind) NOT IN ('explain', 'system', 'show', 'create', 'drop', 'alter', 'set', 'use', 'kill', 'optimize', 'truncate', 'rename', 'check', 'detach', 'attach', 'none')")
+		whereParts = append(whereParts, hideSystemQueriesClause())
 	}
 	if params.User != "" {
 		whereParts = append(whereParts, "user = ?")
@@ -266,7 +275,7 @@ func (c *Client) ListFingerprints(ctx context.Context, params QueryListParams) (
 	args := []interface{}{}
 
 	if params.HideSystemQueries {
-		where += " AND NOT has(databases, 'system') AND lower(query_kind) NOT IN ('explain', 'system', 'show', 'create', 'drop', 'alter', 'set', 'use', 'kill', 'optimize', 'truncate', 'rename', 'check', 'detach', 'attach', 'none')"
+		where += " AND " + hideSystemQueriesClause()
 	}
 
 	if params.FromTime != "" {

--- a/internal/clickhouse/query_log.go
+++ b/internal/clickhouse/query_log.go
@@ -66,12 +66,16 @@ var defaultListParams = QueryListParams{
 }
 
 // hideSystemQueriesClause returns the SQL fragment used to suppress non-user
-// queries when "Hide system queries" is enabled. It excludes noise query kinds
-// (DDL, EXPLAIN, etc.) as well as queries ClickLens issued itself, which are
-// tagged via the log_comment setting so the user only sees the queries they
-// consciously executed.
+// queries when "Hide system queries" is enabled. It does two things:
+//   - excludes DDL/session-control noise by query_kind (CREATE, DROP, ALTER,
+//     EXPLAIN, SET, USE, KILL, OPTIMIZE, etc.), and
+//   - excludes queries ClickLens issued itself, tagged via the log_comment
+//     setting.
+//
+// Notably it does NOT exclude queries merely for touching the system database,
+// so a user's own SELECT ... FROM system.* queries remain visible.
 func hideSystemQueriesClause() string {
-	return "NOT has(databases, 'system') AND lower(query_kind) NOT IN ('explain', 'system', 'show', 'create', 'drop', 'alter', 'set', 'use', 'kill', 'optimize', 'truncate', 'rename', 'check', 'detach', 'attach', 'none') AND log_comment != '" + managedLogComment + "'"
+	return "lower(query_kind) NOT IN ('explain', 'system', 'show', 'create', 'drop', 'alter', 'set', 'use', 'kill', 'optimize', 'truncate', 'rename', 'check', 'detach', 'attach', 'none') AND log_comment != '" + managedLogComment + "'"
 }
 
 func (c *Client) ListQueries(ctx context.Context, params QueryListParams) ([]QueryLogEntry, uint64, error) {

--- a/internal/clickhouse/query_log_test.go
+++ b/internal/clickhouse/query_log_test.go
@@ -1,6 +1,9 @@
 package clickhouse
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestDefaultListParams(t *testing.T) {
 	if defaultListParams.Limit != 50 {
@@ -24,5 +27,19 @@ func TestQueryListParams_Defaults(t *testing.T) {
 	}
 	if p.SortBy != "" {
 		t.Errorf("expected empty sort by, got %s", p.SortBy)
+	}
+}
+
+func TestHideSystemQueriesClause(t *testing.T) {
+	clause := hideSystemQueriesClause()
+
+	for _, want := range []string{
+		"NOT has(databases, 'system')",
+		"lower(query_kind) NOT IN",
+		"log_comment != 'clicklens'",
+	} {
+		if !strings.Contains(clause, want) {
+			t.Errorf("hideSystemQueriesClause() = %q, expected to contain %q", clause, want)
+		}
 	}
 }

--- a/internal/clickhouse/query_log_test.go
+++ b/internal/clickhouse/query_log_test.go
@@ -34,12 +34,17 @@ func TestHideSystemQueriesClause(t *testing.T) {
 	clause := hideSystemQueriesClause()
 
 	for _, want := range []string{
-		"NOT has(databases, 'system')",
 		"lower(query_kind) NOT IN",
 		"log_comment != 'clicklens'",
 	} {
 		if !strings.Contains(clause, want) {
 			t.Errorf("hideSystemQueriesClause() = %q, expected to contain %q", clause, want)
 		}
+	}
+
+	// A user's own SELECT ... FROM system.* is real workload and must remain
+	// visible, so the clause must not blanket-exclude the system database.
+	if strings.Contains(clause, "has(databases, 'system')") {
+		t.Errorf("hideSystemQueriesClause() = %q, should not exclude by databases='system'", clause)
 	}
 }


### PR DESCRIPTION
## Summary

ClickLens's own introspection queries (dashboard reads, `query_log` lookups, health checks, pagination counts, etc.) pollute the Queries and Fingerprints pages, making it hard to see the workload the user actually cares about. This tags ClickLens-issued queries so they can be filtered precisely.

## Approach

Uses ClickHouse's built-in **`log_comment`** session setting (recorded in `system.query_log.log_comment`) rather than a SQL comment, which would pollute the displayed query text and get stripped during normalization.

- **Tagging**: Sets `log_comment='clicklens'` on the `clickhouse-go` connection options in `connect()`. The driver merges `Options.Settings` into _every_ query on the connection (`conn.go:174-177`), so all `c.conn.Query/QueryRow/Exec` calls across the codebase (query_log, dashboard, health, processes, explain, optimizers, trend, plus the pagination `countQuery`) are tagged automatically — zero call-site changes.
- **User SQL stays visible**: User-submitted SQL from the Query Editor goes through a raw HTTP client in `ExecuteQuery` (`execute.go:80`) that bypasses the driver, so it is **not** tagged. This is the desired split: users only see the queries they consciously executed.
- **Filtering**: Folded the exclusion into the existing **"Internal queries"** toggle in `ListQueries` and `ListFingerprints`. This is more precise than the previous `NOT has(databases, 'system')` heuristic, which incorrectly hid a user's own `system.*` queries alongside ClickLens's noise.

## Graceful degradation

If `log_queries` is off or the column is empty, `log_comment != 'clicklens'` matches everything (empty string), so no queries are hidden by accident. Historical rows logged before deployment remain untagged and visible.

## Changes
- `internal/clickhouse/client.go`: add `managedLogComment` const; extract `buildOptions()` helper; set `log_comment` on both HTTP- and Native-scheme options.
- `internal/clickhouse/query_log.go`: extract `hideSystemQueriesClause()`; apply it in `ListQueries` and `ListFingerprints` (de-duplicates the IN-list that was previously copy-pasted).
- Tests: `TestBuildOptions_TagsManagedQueries` (all 4 scheme variants), `TestManagedLogComment`, `TestHideSystemQueriesClause`.

## Test plan
- [x] `make test-unit` — passing
- [x] `make lint` (golangci-lint) — 0 issues
- [x] `go vet ./...` — clean
- [x] `cd web && npm run build` — builds (no frontend changes)
- [x] Manual: verify a Query Editor query appears in the Queries page while ClickLens's own dashboard reads do not (with "Internal queries" off)