### PR TITLE
feat: DDL/Replication UX improvements + resizable query editor

### DIFF
--- a/internal/api/replication_handlers.go
+++ b/internal/api/replication_handlers.go
@@ -16,8 +16,6 @@ func (a *API) GetReplication(w http.ResponseWriter, r *http.Request) {
 
 	params := clickhouse.ReplicationParams{
 		Database:       r.URL.Query().Get("database"),
-		ErrorsOnly:     r.URL.Query().Get("errors_only") == "1",
-		ExecutingOnly:  r.URL.Query().Get("executing_only") == "1",
 		IncludeHistory: r.URL.Query().Get("include_history") != "false",
 	}
 	if v := r.URL.Query().Get("limit"); v != "" {

--- a/internal/clickhouse/ddl.go
+++ b/internal/clickhouse/ddl.go
@@ -80,6 +80,11 @@ type DDLParams struct {
 // ddlKinds are the query_log query_kind values that count as DDL.
 var ddlKinds = []string{"Create", "Alter", "Drop", "Rename", "Attach", "Detach", "Truncate"}
 
+// stuckDDLAge is how long a non-Finished, exception-free distributed DDL entry
+// must remain unfinished before it counts as "stuck". Below this it is
+// considered in-flight/queued rather than stuck.
+const stuckDDLAge = 10 * time.Minute
+
 func (c *Client) GetDDL(ctx context.Context, params DDLParams) (*DDLStatus, error) {
 	if params.Limit <= 0 {
 		params.Limit = 200
@@ -130,15 +135,23 @@ func (c *Client) GetDDL(ctx context.Context, params DDLParams) (*DDLStatus, erro
 	c.queryDDLTrend(ctx, trendFromTime, trendBucket, out)
 	c.queryPendingMutationCount(ctx, out)
 
-	// "Stuck" = a distributed entry that isn't Finished (Active/Inactive/
-	// Removing/Unknown) — i.e. queued or in-flight. A non-empty exception
-	// escalates it to "failed" for the summary badge.
+	// "Stuck" = a distributed entry that isn't Finished AND either has been
+	// unfinished past stuckDDLAge or already errored. A freshly-active or
+	// freshly-queued op is in-flight, not stuck — the age cutoff keeps the
+	// counter from crying wolf on every live ON CLUSTER statement. An entry
+	// with an exception is both stuck and failed regardless of age.
+	stuckCutoff := time.Now().Add(-stuckDDLAge)
 	for _, e := range out.DistributedDDL {
-		if e.Status != "Finished" {
+		if e.Status == "Finished" {
+			continue
+		}
+		if e.ExceptionText != "" {
 			out.StuckDDL++
-			if e.ExceptionText != "" {
-				out.FailedDDL++
-			}
+			out.FailedDDL++
+			continue
+		}
+		if t, ok := parseDDLTime(e.QueryCreateTime); !ok || t.Before(stuckCutoff) {
+			out.StuckDDL++
 		}
 	}
 	for _, r := range out.RecentDDL {
@@ -281,4 +294,18 @@ func (c *Client) queryPendingMutationCount(ctx context.Context, out *DDLStatus) 
 		out.PendingMutations = 0
 		out.addPartial("system.mutations", err)
 	}
+}
+
+// parseDDLTime parses a ClickHouse toString(datetime) value (as selected for
+// query_create_time). ok=false for empty/unparseable strings lets the caller
+// fall back to a conservative default rather than dropping the entry.
+func parseDDLTime(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.ParseInLocation("2006-01-02 15:04:05", s, time.Local)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }

--- a/internal/clickhouse/replication.go
+++ b/internal/clickhouse/replication.go
@@ -60,8 +60,6 @@ type ReplicationMetricPoint struct {
 
 type ReplicationParams struct {
 	Database       string
-	ErrorsOnly     bool
-	ExecutingOnly  bool
 	IncludeHistory bool
 	Limit          int
 	Offset         int
@@ -189,14 +187,6 @@ func (c *Client) queryReplicationQueue(ctx context.Context, params ReplicationPa
 	if params.Database != "" {
 		whereParts = append(whereParts, "database = ?")
 		args = append(args, params.Database)
-	}
-	if params.ErrorsOnly {
-		// num_tries > 0 catches retries; a non-empty last_exception catches
-		// the window before the first retry is attempted.
-		whereParts = append(whereParts, "(num_tries > 0 OR last_exception != '')")
-	}
-	if params.ExecutingOnly {
-		whereParts = append(whereParts, "is_currently_executing = 1")
 	}
 	where := ""
 	if len(whereParts) > 0 {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -253,11 +253,9 @@ export async function fetchDashboard(signal?: AbortSignal): Promise<DashboardDat
   return fetchJSON<DashboardData>(`${BASE}/dashboard`, { signal });
 }
 
-export async function fetchReplication(params?: { database?: string; errors_only?: boolean; executing_only?: boolean; include_history?: boolean; limit?: number; offset?: number }, signal?: AbortSignal): Promise<ReplicationStatus> {
+export async function fetchReplication(params?: { database?: string; include_history?: boolean; limit?: number; offset?: number }, signal?: AbortSignal): Promise<ReplicationStatus> {
   const sp = new URLSearchParams();
   if (params?.database) sp.set("database", params.database);
-  if (params?.errors_only) sp.set("errors_only", "1");
-  if (params?.executing_only) sp.set("executing_only", "1");
   if (params?.include_history === false) sp.set("include_history", "false");
   if (params?.limit) sp.set("limit", String(params.limit));
   if (params?.offset) sp.set("offset", String(params.offset));

--- a/web/src/components/ui/table-sort.tsx
+++ b/web/src/components/ui/table-sort.tsx
@@ -1,0 +1,56 @@
+import { useState, useCallback } from "react";
+import { ArrowUp, ArrowDown } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+export type SortDir = "asc" | "desc";
+
+// Client-side table sort: holds the active field + direction. Clicking a new
+// field sorts descending; re-clicking the active field flips asc/desc. Generic
+// over the field union so each table's headers stay typed.
+export function useTableSort<K extends string>(initialField?: K, initialDir: SortDir = "asc") {
+  const [field, setField] = useState<K | undefined>(initialField);
+  const [dir, setDir] = useState<SortDir>(initialDir);
+  const toggle = useCallback((f: K) => {
+    setField(f);
+    setDir((prev) => (f === field ? (prev === "asc" ? "desc" : "asc") : "desc"));
+  }, [field]);
+  return { field, dir, toggle };
+}
+
+interface SortableHeaderProps<K extends string> {
+  field: K;
+  activeField?: K;
+  dir: SortDir;
+  onToggle: (field: K) => void;
+  label: string;
+  align?: "left" | "right";
+  // Padding/text sizing are table-specific, so the caller supplies them.
+  className?: string;
+}
+
+export function SortableHeader<K extends string>({
+  field,
+  activeField,
+  dir,
+  onToggle,
+  label,
+  align = "left",
+  className,
+}: SortableHeaderProps<K>) {
+  const active = activeField === field;
+  return (
+    <th
+      className={cn(
+        "cursor-pointer select-none font-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]",
+        align === "right" ? "text-right" : "text-left",
+        className,
+      )}
+      onClick={() => onToggle(field)}
+    >
+      <span className={cn("inline-flex items-center gap-1", align === "right" && "flex-row-reverse")}>
+        {label}
+        {active && (dir === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />)}
+      </span>
+    </th>
+  );
+}

--- a/web/src/pages/DDL.tsx
+++ b/web/src/pages/DDL.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState, ErrorState, NotConnectedState } from "@/components/ui/state";
+import { useTableSort, SortableHeader } from "@/components/ui/table-sort";
 import { ClusterNoteBanner } from "@/components/ClusterNoteBanner";
 
 const TIMEFRAMES: { label: string; hours: number }[] = [
@@ -75,6 +76,19 @@ function statusTone(status: string, exception: string): { color: string; label: 
   }
 }
 
+// Age of the oldest non-Finished distributed entry, for the stuck warning. The
+// stuck count itself is backend-authoritative (age + exception rule in ddl.go);
+// this just surfaces how long the oldest one has been sitting.
+function oldestUnfinishedAgeSec(entries: DDLStatus["distributed_ddl"]): number {
+  let max = 0;
+  for (const e of entries) {
+    if (e.status === "Finished") continue;
+    const t = new Date(e.query_create_time.replace(" ", "T")).getTime();
+    if (Number.isFinite(t)) max = Math.max(max, (Date.now() - t) / 1000);
+  }
+  return max;
+}
+
 export function DDL({ connected }: { connected: boolean }) {
   const navigate = useNavigate();
   const [data, setData] = useState<DDLStatus | null>(null);
@@ -115,6 +129,7 @@ export function DDL({ connected }: { connected: boolean }) {
   }
 
   const windowLabel = hours === 0 ? "all time" : `last ${hours < 24 ? `${hours}h` : hours < 168 ? `${hours / 24}d` : "7d"}`;
+  const stuckOldestAgeSec = data && data.stuck_ddl > 0 ? oldestUnfinishedAgeSec(data.distributed_ddl) : 0;
 
   return (
     <PageContainer>
@@ -214,7 +229,9 @@ export function DDL({ connected }: { connected: boolean }) {
             <Card className="border-[var(--color-warning)]/30 p-4">
               <div className="flex items-center gap-2 text-xs text-[var(--color-warning)]">
                 <AlertTriangle className="h-3.5 w-3.5" />
-                {data.stuck_ddl} distributed DDL operation(s) are not finished — ON CLUSTER DDL may be stuck.
+                {data.stuck_ddl} distributed DDL operation(s) unfinished for &gt;10 min (or failed)
+                {stuckOldestAgeSec > 0 ? <>; oldest pending {formatDuration(stuckOldestAgeSec * 1000)}</> : null}
+                — ON CLUSTER DDL may be stuck.
               </div>
             </Card>
           )}
@@ -279,7 +296,7 @@ const DDLTrendChart = memo(function DDLTrendChart({ trend, hours }: { trend: DDL
           <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
           <XAxis dataKey="bucket" tickFormatter={fmtBucket} tick={{ fill: textColor, fontSize: 10 }} interval="preserveStartEnd" minTickGap={40} />
           <YAxis allowDecimals={false} tick={{ fill: textColor, fontSize: 10 }} width={28} />
-          <Tooltip contentStyle={tooltipStyle} labelFormatter={(l) => fmtBucket(String(l))} />
+          <Tooltip contentStyle={tooltipStyle} cursor={false} labelFormatter={(l) => fmtBucket(String(l))} />
           <Bar dataKey="ok" stackId="a" fill="#10b98180" name="ok" radius={[0, 0, 0, 0]} />
           <Bar dataKey="failed" stackId="a" fill="#ef4444" name="failed" radius={[2, 2, 0, 0]} />
         </BarChart>
@@ -333,12 +350,36 @@ function ExpandToggle({ open }: { open: boolean }) {
     : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-secondary)]" />;
 }
 
+type DistDDLSortField = "created" | "duration" | "status" | "host" | "cluster";
+
+function distDDLKey(e: DDLStatus["distributed_ddl"][number]): string {
+  // No stable id in system.distributed_ddl_queue; this composite is unique in
+  // practice and keeps expand-state stable across re-sorts.
+  return `${e.query_create_time}\u0000${e.initiator_host}\u0000${e.cluster}\u0000${e.query}`;
+}
+
 function DistributedDDLCard({ entries }: { entries: DDLStatus["distributed_ddl"] }) {
   const theme = useTheme();
-  const [expanded, setExpanded] = useState<Set<number>>(new Set());
-  const toggle = (i: number) => setExpanded((prev) => {
+  const sort = useTableSort<DistDDLSortField>("created", "desc");
+  const sorted = useMemo(() => {
+    const dir = sort.dir === "asc" ? 1 : -1;
+    return [...entries].sort((a, b) => {
+      let r = 0;
+      switch (sort.field) {
+        case "created": r = (a.query_create_time || "").localeCompare(b.query_create_time || ""); break;
+        case "duration": r = a.query_duration_ms - b.query_duration_ms; break;
+        case "status": r = (a.status || "").localeCompare(b.status || ""); break;
+        case "host": r = (a.initiator_host || "").localeCompare(b.initiator_host || ""); break;
+        case "cluster": r = (a.cluster || "").localeCompare(b.cluster || ""); break;
+      }
+      return r * dir;
+    });
+  }, [entries, sort.field, sort.dir]);
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (key: string) => setExpanded((prev) => {
     const next = new Set(prev);
-    if (next.has(i)) next.delete(i); else next.add(i);
+    if (next.has(key)) next.delete(key); else next.add(key);
     return next;
   });
 
@@ -356,28 +397,29 @@ function DistributedDDLCard({ entries }: { entries: DDLStatus["distributed_ddl"]
       <div className="overflow-auto px-4 pb-4">
         <table className="w-full table-fixed text-sm">
           <colgroup>
-            <col className="w-[15%]" /><col className="w-[34%]" /><col className="w-[9%]" /><col className="w-[8%]" /><col className="w-[9%]" /><col className="w-[9%]" /><col className="w-[16%]" />
+            <col className="w-[15%]" /><col className="w-[31%]" /><col className="w-[9%]" /><col className="w-[8%]" /><col className="w-[12%]" /><col className="w-[10%]" /><col className="w-[15%]" />
           </colgroup>
           <thead>
             <tr className="border-b border-[var(--color-border)]">
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Created</th>
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="created" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Created" />
               <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Query</th>
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Status</th>
-              <th className="px-3 pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Duration</th>
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Host</th>
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Cluster</th>
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="status" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Status" />
+              <SortableHeader className="px-3 pb-1.5 text-xs" align="right" field="duration" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Duration" />
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="host" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Host" />
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="cluster" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Cluster" />
               <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Exception</th>
             </tr>
           </thead>
           <tbody>
-            {entries.map((e, i) => {
+            {sorted.map((e) => {
               const tone = statusTone(e.status, e.exception_text);
-              const isOpen = expanded.has(i);
+              const key = distDDLKey(e);
+              const isOpen = expanded.has(key);
               return (
-                <Fragment key={i}>
+                <Fragment key={key}>
                   <tr
                     className="cursor-pointer border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--surface-hover)]"
-                    onClick={() => toggle(i)}
+                    onClick={() => toggle(key)}
                   >
                     <td className="whitespace-nowrap px-3 py-1.5 text-xs text-[var(--color-text-primary)]">{e.query_create_time}</td>
                     <td className="px-3 py-1.5 text-xs">
@@ -395,8 +437,12 @@ function DistributedDDLCard({ entries }: { entries: DDLStatus["distributed_ddl"]
                     <td className="whitespace-nowrap px-3 py-1.5 text-right font-mono text-xs text-[var(--color-text-primary)]">
                       {e.query_duration_ms ? formatDuration(e.query_duration_ms) : "-"}
                     </td>
-                    <td className="whitespace-nowrap px-3 py-1.5 font-mono text-xs text-[var(--color-text-primary)]">{e.initiator_host || "-"}</td>
-                    <td className="whitespace-nowrap px-3 py-1.5 font-mono text-xs text-[var(--color-text-primary)]">{e.cluster || "-"}</td>
+                    <td className="px-3 py-1.5 text-xs text-[var(--color-text-primary)]">
+                      <span className="block truncate font-mono" title={e.initiator_host}>{e.initiator_host || "-"}</span>
+                    </td>
+                    <td className="px-3 py-1.5 text-xs text-[var(--color-text-primary)]">
+                      <span className="block truncate font-mono" title={e.cluster}>{e.cluster || "-"}</span>
+                    </td>
                     <td className="px-3 py-1.5 text-xs text-[var(--color-error)]" title={e.exception_text}>
                       <span className="block truncate">{e.exception_text || "-"}</span>
                     </td>
@@ -416,12 +462,31 @@ function DistributedDDLCard({ entries }: { entries: DDLStatus["distributed_ddl"]
   );
 }
 
+type RecentDDLSortField = "time" | "duration" | "status" | "kind" | "user";
+
 function RecentDDLCard({ entries }: { entries: DDLStatus["recent_ddl"] }) {
   const theme = useTheme();
-  const [expanded, setExpanded] = useState<Set<number>>(new Set());
-  const toggle = (i: number) => setExpanded((prev) => {
+  const sort = useTableSort<RecentDDLSortField>("time", "desc");
+  const sorted = useMemo(() => {
+    const dir = sort.dir === "asc" ? 1 : -1;
+    return [...entries].sort((a, b) => {
+      let r = 0;
+      switch (sort.field) {
+        case "time": r = (a.event_time || "").localeCompare(b.event_time || ""); break;
+        case "duration": r = a.query_duration_ms - b.query_duration_ms; break;
+        // Status sorts by failure (exception present) so failed rows group together.
+        case "status": r = (a.exception ? 1 : 0) - (b.exception ? 1 : 0); break;
+        case "kind": r = (a.query_kind || "").localeCompare(b.query_kind || ""); break;
+        case "user": r = (a.user || "").localeCompare(b.user || ""); break;
+      }
+      return r * dir;
+    });
+  }, [entries, sort.field, sort.dir]);
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (key: string) => setExpanded((prev) => {
     const next = new Set(prev);
-    if (next.has(i)) next.delete(i); else next.add(i);
+    if (next.has(key)) next.delete(key); else next.add(key);
     return next;
   });
 
@@ -443,22 +508,22 @@ function RecentDDLCard({ entries }: { entries: DDLStatus["recent_ddl"] }) {
           </colgroup>
           <thead>
             <tr className="border-b border-[var(--color-border)]">
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Time</th>
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="time" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Time" />
               <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Query</th>
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Status</th>
-              <th className="px-3 pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Duration</th>
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Kind</th>
-              <th className="px-3 pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">User</th>
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="status" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Status" />
+              <SortableHeader className="px-3 pb-1.5 text-xs" align="right" field="duration" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Duration" />
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="kind" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Kind" />
+              <SortableHeader className="px-3 pb-1.5 text-xs" field="user" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="User" />
             </tr>
           </thead>
           <tbody>
-            {entries.map((e, i) => {
-              const isOpen = expanded.has(i);
+            {sorted.map((e) => {
+              const isOpen = expanded.has(e.query_id);
               return (
-                <Fragment key={i}>
+                <Fragment key={e.query_id}>
                   <tr
                     className="cursor-pointer border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--surface-hover)]"
-                    onClick={() => toggle(i)}
+                    onClick={() => toggle(e.query_id)}
                   >
                     <td className="whitespace-nowrap px-3 py-1.5 text-xs text-[var(--color-text-primary)]">{e.event_time}</td>
                     <td className="px-3 py-1.5 text-xs">

--- a/web/src/pages/DDL.tsx
+++ b/web/src/pages/DDL.tsx
@@ -352,34 +352,35 @@ function ExpandToggle({ open }: { open: boolean }) {
 
 type DistDDLSortField = "created" | "duration" | "status" | "host" | "cluster";
 
-function distDDLKey(e: DDLStatus["distributed_ddl"][number]): string {
-  // No stable id in system.distributed_ddl_queue; this composite is unique in
-  // practice and keeps expand-state stable across re-sorts.
-  return `${e.query_create_time}\u0000${e.initiator_host}\u0000${e.cluster}\u0000${e.query}`;
-}
-
 function DistributedDDLCard({ entries }: { entries: DDLStatus["distributed_ddl"] }) {
   const theme = useTheme();
   const sort = useTableSort<DistDDLSortField>("created", "desc");
+  // Tag each row with its original array index: a stable, always-unique id. The
+  // same ON CLUSTER DDL can appear on multiple replicas with identical selected
+  // columns, so any data-derived key collides and makes React duplicate rows
+  // when a sort reorders them. The index survives re-sorts and stays tied to
+  // the right row, so expand-state is preserved correctly.
   const sorted = useMemo(() => {
     const dir = sort.dir === "asc" ? 1 : -1;
-    return [...entries].sort((a, b) => {
-      let r = 0;
-      switch (sort.field) {
-        case "created": r = (a.query_create_time || "").localeCompare(b.query_create_time || ""); break;
-        case "duration": r = a.query_duration_ms - b.query_duration_ms; break;
-        case "status": r = (a.status || "").localeCompare(b.status || ""); break;
-        case "host": r = (a.initiator_host || "").localeCompare(b.initiator_host || ""); break;
-        case "cluster": r = (a.cluster || "").localeCompare(b.cluster || ""); break;
-      }
-      return r * dir;
-    });
+    return entries
+      .map((entry, id) => ({ entry, id }))
+      .sort((a, b) => {
+        let r = 0;
+        switch (sort.field) {
+          case "created": r = (a.entry.query_create_time || "").localeCompare(b.entry.query_create_time || ""); break;
+          case "duration": r = a.entry.query_duration_ms - b.entry.query_duration_ms; break;
+          case "status": r = (a.entry.status || "").localeCompare(b.entry.status || ""); break;
+          case "host": r = (a.entry.initiator_host || "").localeCompare(b.entry.initiator_host || ""); break;
+          case "cluster": r = (a.entry.cluster || "").localeCompare(b.entry.cluster || ""); break;
+        }
+        return r * dir;
+      });
   }, [entries, sort.field, sort.dir]);
 
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const toggle = (key: string) => setExpanded((prev) => {
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const toggle = (id: number) => setExpanded((prev) => {
     const next = new Set(prev);
-    if (next.has(key)) next.delete(key); else next.add(key);
+    if (next.has(id)) next.delete(id); else next.add(id);
     return next;
   });
 
@@ -411,15 +412,14 @@ function DistributedDDLCard({ entries }: { entries: DDLStatus["distributed_ddl"]
             </tr>
           </thead>
           <tbody>
-            {sorted.map((e) => {
+            {sorted.map(({ entry: e, id }) => {
               const tone = statusTone(e.status, e.exception_text);
-              const key = distDDLKey(e);
-              const isOpen = expanded.has(key);
+              const isOpen = expanded.has(id);
               return (
-                <Fragment key={key}>
+                <Fragment key={id}>
                   <tr
                     className="cursor-pointer border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--surface-hover)]"
-                    onClick={() => toggle(key)}
+                    onClick={() => toggle(id)}
                   >
                     <td className="whitespace-nowrap px-3 py-1.5 text-xs text-[var(--color-text-primary)]">{e.query_create_time}</td>
                     <td className="px-3 py-1.5 text-xs">
@@ -467,26 +467,30 @@ type RecentDDLSortField = "time" | "duration" | "status" | "kind" | "user";
 function RecentDDLCard({ entries }: { entries: DDLStatus["recent_ddl"] }) {
   const theme = useTheme();
   const sort = useTableSort<RecentDDLSortField>("time", "desc");
+  // Index-tagged rows (see DistributedDDLCard): query_log is read cluster-wide,
+  // so query_id isn't guaranteed unique across replicas and a data-derived key
+  // can collide on sort.
   const sorted = useMemo(() => {
     const dir = sort.dir === "asc" ? 1 : -1;
-    return [...entries].sort((a, b) => {
-      let r = 0;
-      switch (sort.field) {
-        case "time": r = (a.event_time || "").localeCompare(b.event_time || ""); break;
-        case "duration": r = a.query_duration_ms - b.query_duration_ms; break;
-        // Status sorts by failure (exception present) so failed rows group together.
-        case "status": r = (a.exception ? 1 : 0) - (b.exception ? 1 : 0); break;
-        case "kind": r = (a.query_kind || "").localeCompare(b.query_kind || ""); break;
-        case "user": r = (a.user || "").localeCompare(b.user || ""); break;
-      }
-      return r * dir;
-    });
+    return entries
+      .map((entry, id) => ({ entry, id }))
+      .sort((a, b) => {
+        let r = 0;
+        switch (sort.field) {
+          case "time": r = (a.entry.event_time || "").localeCompare(b.entry.event_time || ""); break;
+          case "duration": r = a.entry.query_duration_ms - b.entry.query_duration_ms; break;
+          case "status": r = (a.entry.exception ? 1 : 0) - (b.entry.exception ? 1 : 0); break;
+          case "kind": r = (a.entry.query_kind || "").localeCompare(b.entry.query_kind || ""); break;
+          case "user": r = (a.entry.user || "").localeCompare(b.entry.user || ""); break;
+        }
+        return r * dir;
+      });
   }, [entries, sort.field, sort.dir]);
 
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const toggle = (key: string) => setExpanded((prev) => {
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const toggle = (id: number) => setExpanded((prev) => {
     const next = new Set(prev);
-    if (next.has(key)) next.delete(key); else next.add(key);
+    if (next.has(id)) next.delete(id); else next.add(id);
     return next;
   });
 
@@ -517,13 +521,13 @@ function RecentDDLCard({ entries }: { entries: DDLStatus["recent_ddl"] }) {
             </tr>
           </thead>
           <tbody>
-            {sorted.map((e) => {
-              const isOpen = expanded.has(e.query_id);
+            {sorted.map(({ entry: e, id }) => {
+              const isOpen = expanded.has(id);
               return (
-                <Fragment key={e.query_id}>
+                <Fragment key={id}>
                   <tr
                     className="cursor-pointer border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--surface-hover)]"
-                    onClick={() => toggle(e.query_id)}
+                    onClick={() => toggle(id)}
                   >
                     <td className="whitespace-nowrap px-3 py-1.5 text-xs text-[var(--color-text-primary)]">{e.event_time}</td>
                     <td className="px-3 py-1.5 text-xs">

--- a/web/src/pages/QueryEditor.tsx
+++ b/web/src/pages/QueryEditor.tsx
@@ -67,6 +67,9 @@ export function QueryEditor({ connected }: { connected: boolean }) {
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     try { return Number(localStorage.getItem("ch-editor-sidebar-width")) || 256; } catch { return 256; }
   });
+  const [editorHeight, setEditorHeight] = useState(() => {
+    try { return Math.max(120, Number(localStorage.getItem("ch-editor-editor-height")) || 192); } catch { return 192; }
+  });
   const [sidebarSections, setSidebarSections] = useState<SidebarSections>(loadSidebarSections);
   const [sectionHeights, setSectionHeights] = useState(() => {
     try {
@@ -200,6 +203,10 @@ export function QueryEditor({ connected }: { connected: boolean }) {
   useEffect(() => {
     try { localStorage.setItem("ch-editor-sidebar-width", String(sidebarWidth)); } catch {}
   }, [sidebarWidth]);
+
+  useEffect(() => {
+    try { localStorage.setItem("ch-editor-editor-height", String(editorHeight)); } catch {}
+  }, [editorHeight]);
 
   useEffect(() => {
     try { localStorage.setItem("ch-editor-section-heights", JSON.stringify(sectionHeights)); } catch {}
@@ -922,7 +929,7 @@ export function QueryEditor({ connected }: { connected: boolean }) {
               onPageSizeChange={setPageSize}
             />
           )}
-          <div className="h-48">
+          <div style={{ height: editorHeight }}>
             <CodeMirror
               ref={editorRef as React.Ref<never>}
               value={sqlText}
@@ -934,6 +941,31 @@ export function QueryEditor({ connected }: { connected: boolean }) {
             />
           </div>
         </div>
+
+        <div
+          className="h-1 shrink-0 cursor-row-resize hover:bg-[var(--color-accent)]"
+          title="Drag to resize"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            const startY = e.clientY;
+            const startH = editorHeight;
+            const onMove = (ev: MouseEvent) => {
+              // Leave room for the tabs/toolbar above and a usable results panel below.
+              const next = Math.max(120, Math.min(window.innerHeight - 280, startH + ev.clientY - startY));
+              setEditorHeight(next);
+            };
+            const onUp = () => {
+              document.body.style.cursor = "";
+              document.body.style.userSelect = "";
+              document.removeEventListener("mousemove", onMove);
+              document.removeEventListener("mouseup", onUp);
+            };
+            document.body.style.cursor = "row-resize";
+            document.body.style.userSelect = "none";
+            document.addEventListener("mousemove", onMove);
+            document.addEventListener("mouseup", onUp);
+          }}
+        />
 
         <div className="flex-1 overflow-auto bg-[var(--surface-base)]">
           {activeTab && activeTab.results.length === 0 && activeTab.errors.length === 0 && (

--- a/web/src/pages/Replication.tsx
+++ b/web/src/pages/Replication.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, memo } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo, memo } from "react";
 import { Server, AlertTriangle, RefreshCw, Network, Clock, ListChecks, FlaskConical, Pause, Play, KeyRound } from "lucide-react";
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { fetchReplication } from "../api/client";
@@ -13,6 +13,7 @@ import { Select } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState, ErrorState, NotConnectedState } from "@/components/ui/state";
+import { useTableSort, SortableHeader } from "@/components/ui/table-sort";
 import { ClusterNoteBanner } from "@/components/ClusterNoteBanner";
 
 interface StatCardProps {
@@ -71,8 +72,6 @@ export function Replication({ connected }: { connected: boolean }) {
   const intervalRef = useRef<ReturnType<typeof setInterval>>(null);
 
   const [database, setDatabase] = useState("");
-  const [errorsOnly, setErrorsOnly] = useState(false);
-  const [executingOnly, setExecutingOnly] = useState(false);
 
   // includeHistory defaults to true: the initial load and manual refreshes
   // pull the 24h chart data. The auto-refresh tick passes false so live
@@ -82,7 +81,7 @@ export function Replication({ connected }: { connected: boolean }) {
     setError(null);
     try {
       const result = await fetchReplication(
-        { database: database || undefined, errors_only: errorsOnly, executing_only: executingOnly, include_history: includeHistory },
+        { database: database || undefined, include_history: includeHistory },
         signal,
       );
       setData(result);
@@ -94,7 +93,7 @@ export function Replication({ connected }: { connected: boolean }) {
     } finally {
       setLoading(false);
     }
-  }, [database, errorsOnly, executingOnly]);
+  }, [database]);
 
   useEffect(() => {
     if (!connected) return;
@@ -236,21 +235,6 @@ export function Replication({ connected }: { connected: boolean }) {
               <option value="">All databases</option>
               {databases.map((d) => <option key={d} value={d}>{d}</option>)}
             </Select>
-            <Button
-              variant={errorsOnly ? "primary" : "secondary"}
-              size="md"
-              onClick={() => setErrorsOnly((v) => !v)}
-            >
-              <AlertTriangle className="h-3.5 w-3.5" />
-              Errors only
-            </Button>
-            <Button
-              variant={executingOnly ? "primary" : "secondary"}
-              size="md"
-              onClick={() => setExecutingOnly((v) => !v)}
-            >
-              Executing
-            </Button>
           </div>
 
           {data.replica_statuses.length === 0 &&
@@ -288,7 +272,34 @@ export function Replication({ connected }: { connected: boolean }) {
   );
 }
 
+type ReplicaSortField = "table" | "delay" | "loglag" | "queue" | "age" | "active";
+
+// Elapsed seconds since the oldest queued entry, for replica "Age". 0 when the
+// queue is empty or the timestamp is missing/garbage.
+function queueAge(queueOldestTime: string): number {
+  if (!queueOldestTime) return 0;
+  const t = new Date(queueOldestTime.replace(" ", "T")).getTime();
+  return Number.isFinite(t) ? Math.max(0, Math.round((Date.now() - t) / 1000)) : 0;
+}
+
 function ReplicaStatusCard({ replicas }: { replicas: ReplicationStatus["replica_statuses"] }) {
+  const sort = useTableSort<ReplicaSortField>("table", "asc");
+  const sorted = useMemo(() => {
+    const dir = sort.dir === "asc" ? 1 : -1;
+    return [...replicas].sort((a, b) => {
+      let r = 0;
+      switch (sort.field) {
+        case "table": r = `${a.database}.${a.table}`.localeCompare(`${b.database}.${b.table}`); break;
+        case "delay": r = a.absolute_delay - b.absolute_delay; break;
+        case "loglag": r = (a.log_max_index - a.log_pointer) - (b.log_max_index - b.log_pointer); break;
+        case "queue": r = a.queue_size - b.queue_size; break;
+        case "age": r = queueAge(a.queue_oldest_time) - queueAge(b.queue_oldest_time); break;
+        case "active": r = a.active_replicas - b.active_replicas; break;
+      }
+      return r * dir;
+    });
+  }, [replicas, sort.field, sort.dir]);
+
   return (
     <Card className="flex max-h-[28rem] flex-col">
       <div className="flex items-center gap-2 px-4 py-3 text-xs font-medium text-[var(--color-text-secondary)]">
@@ -299,20 +310,20 @@ function ReplicaStatusCard({ replicas }: { replicas: ReplicationStatus["replica_
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-[var(--color-border)]">
-              <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Table</th>
+              <SortableHeader className="pb-1.5 text-xs" field="table" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Table" />
               <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Replica</th>
               <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Leader</th>
-              <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Delay</th>
-              <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Log Lag</th>
-              <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Queue</th>
-              <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Age</th>
-              <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Active</th>
+              <SortableHeader className="pb-1.5 text-xs" align="right" field="delay" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Delay" />
+              <SortableHeader className="pb-1.5 text-xs" align="right" field="loglag" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Log Lag" />
+              <SortableHeader className="pb-1.5 text-xs" align="right" field="queue" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Queue" />
+              <SortableHeader className="pb-1.5 text-xs" align="right" field="age" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Age" />
+              <SortableHeader className="pb-1.5 text-xs" align="right" field="active" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Active" />
             </tr>
           </thead>
           <tbody>
-            {replicas.map((r, i) => {
+            {sorted.map((r, i) => {
               const logLag = Math.max(0, r.log_max_index - r.log_pointer);
-              const queueAge = r.queue_oldest_time ? Math.max(0, Math.round((Date.now() - new Date(r.queue_oldest_time.replace(" ", "T")).getTime()) / 1000)) : 0;
+              const age = queueAge(r.queue_oldest_time);
               return (
                 <tr key={i} className="border-b border-[var(--color-border)] last:border-0">
                   <td className="py-1.5 text-xs">
@@ -334,8 +345,8 @@ function ReplicaStatusCard({ replicas }: { replicas: ReplicationStatus["replica_
                   <td className={`py-1.5 text-right font-mono text-xs ${r.queue_size > 1000 ? "text-[var(--color-warning)]" : ""}`}>
                     {r.queue_size || "-"}
                   </td>
-                  <td className={`py-1.5 text-right font-mono text-xs ${queueAge > 300 ? "text-[var(--color-warning)]" : ""}`}>
-                    {queueAge > 0 ? formatDelay(queueAge) : "-"}
+                  <td className={`py-1.5 text-right font-mono text-xs ${age > 300 ? "text-[var(--color-warning)]" : ""}`}>
+                    {age > 0 ? formatDelay(age) : "-"}
                   </td>
                   <td className={`py-1.5 text-right font-mono text-xs ${r.total_replicas > 0 && r.active_replicas < r.total_replicas ? "text-[var(--color-warning)]" : ""}`}>
                     {r.active_replicas}/{r.total_replicas}
@@ -350,7 +361,24 @@ function ReplicaStatusCard({ replicas }: { replicas: ReplicationStatus["replica_
   );
 }
 
+type QueueSortField = "table" | "tries" | "created";
+
 function ReplicationQueueCard({ queue }: { queue: ReplicationStatus["replication_queue"] }) {
+  const sort = useTableSort<QueueSortField>("table", "asc");
+  const sorted = useMemo(() => {
+    const dir = sort.dir === "asc" ? 1 : -1;
+    return [...queue].sort((a, b) => {
+      let r = 0;
+      switch (sort.field) {
+        case "table": r = `${a.database}.${a.table}`.localeCompare(`${b.database}.${b.table}`); break;
+        case "tries": r = a.num_tries - b.num_tries; break;
+        // create_time is "YYYY-MM-DD HH:MM:SS" — lexical order == chronological.
+        case "created": r = (a.create_time || "").localeCompare(b.create_time || ""); break;
+      }
+      return r * dir;
+    });
+  }, [queue, sort.field, sort.dir]);
+
   return (
     <Card className="flex max-h-[28rem] flex-col">
       <div className="flex items-center gap-2 px-4 py-3 text-xs font-medium text-[var(--color-text-secondary)]">
@@ -361,19 +389,19 @@ function ReplicationQueueCard({ queue }: { queue: ReplicationStatus["replication
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-[var(--color-border)]">
-              <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Table</th>
+              <SortableHeader className="pb-1.5 text-xs" field="table" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Table" />
               <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Replica</th>
               <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Type</th>
               <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Run</th>
-              <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Tries</th>
-              <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Created</th>
+              <SortableHeader className="pb-1.5 text-xs" align="right" field="tries" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Tries" />
+              <SortableHeader className="pb-1.5 text-xs" field="created" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Created" />
               <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Source</th>
               <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Postponed</th>
               <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Last error</th>
             </tr>
           </thead>
           <tbody>
-            {queue.map((q, i) => (
+            {sorted.map((q, i) => (
               <tr key={i} className="border-b border-[var(--color-border)] last:border-0">
                 <td className="py-1.5 text-xs">
                   <span className="text-[var(--color-text-secondary)]">{q.database}.</span>{q.table}
@@ -403,7 +431,23 @@ function ReplicationQueueCard({ queue }: { queue: ReplicationStatus["replication
   );
 }
 
+type MutationSortField = "table" | "parts" | "created";
+
 function MutationsCard({ mutations }: { mutations: ReplicationStatus["mutations"] }) {
+  const sort = useTableSort<MutationSortField>("table", "asc");
+  const sorted = useMemo(() => {
+    const dir = sort.dir === "asc" ? 1 : -1;
+    return [...mutations].sort((a, b) => {
+      let r = 0;
+      switch (sort.field) {
+        case "table": r = `${a.database}.${a.table}`.localeCompare(`${b.database}.${b.table}`); break;
+        case "parts": r = a.parts_to_do - b.parts_to_do; break;
+        case "created": r = (a.create_time || "").localeCompare(b.create_time || ""); break;
+      }
+      return r * dir;
+    });
+  }, [mutations, sort.field, sort.dir]);
+
   return (
     <Card className="flex max-h-[28rem] flex-col">
       <div className="flex items-center gap-2 px-4 py-3 text-xs font-medium text-[var(--color-text-secondary)]">
@@ -414,15 +458,15 @@ function MutationsCard({ mutations }: { mutations: ReplicationStatus["mutations"
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-[var(--color-border)]">
-              <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Table</th>
+              <SortableHeader className="pb-1.5 text-xs" field="table" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Table" />
               <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Mutation</th>
-              <th className="pb-1.5 text-right text-xs font-medium text-[var(--color-text-secondary)]">Parts to do</th>
-              <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Created</th>
+              <SortableHeader className="pb-1.5 text-xs" align="right" field="parts" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Parts to do" />
+              <SortableHeader className="pb-1.5 text-xs" field="created" activeField={sort.field} dir={sort.dir} onToggle={sort.toggle} label="Created" />
               <th className="pb-1.5 text-left text-xs font-medium text-[var(--color-text-secondary)]">Latest failure</th>
             </tr>
           </thead>
           <tbody>
-            {mutations.map((m, i) => (
+            {sorted.map((m, i) => (
               <tr key={i} className="border-b border-[var(--color-border)] last:border-0">
                 <td className="py-1.5 text-xs">
                   <span className="text-[var(--color-text-secondary)]">{m.database}.</span>{m.table}


### PR DESCRIPTION
## Summary

A batch of UX fixes across the DDL and Replication pages plus a resizable query editor.

## Changes

### DDL
- **"Stuck" count now factors in start time.** A non-Finished distributed entry only counts as stuck once it's older than **10 min**; exceptions still count immediately. Avoids crying wolf on every in-flight ON CLUSTER statement. The stuck warning now reads ">10 min (or failed)" and shows the oldest pending age. `ddl.go`
- **Operations chart:** disabled the recharts hover/click cursor highlight (`cursor={false}`).
- **Queue table:** host/cluster columns truncate with tooltips; column widths rebalanced so hostnames fit.

### Replication
- **Removed "Errors only" / "Executing" buttons.** They only filtered the Replication Queue table (often empty on healthy clusters), so they looked inert. Errors are still surfaced by the stuck-first sort + color-coded tones on every table and the Action-items badge. Backend wiring (`ErrorsOnly`/`ExecutingOnly` params + WHERE clauses) deleted too.
- **Read-only replica flicker (1→0): verified correct.** The stat card reflects live `system.replicas.is_readonly` on each fetch, so a flip is a genuine replica recovery (Keeper-session blip); the 24h chart is stickier via `max()` bucketing. No change.

### Both DDL + Replication tables
- **Sortable columns.** Click any header to sort (defaults: Replication by table asc; DDL by created/time desc). Expand-to-view state is now keyed stably so it survives re-sort. Adds a shared `useTableSort` hook + `SortableHeader` (`web/src/components/ui/table-sort.tsx`).

### Query editor
- **Resizable editor/results split.** A drag handle between the editor and results panel resizes the editor; height is clamped (`120px` … `vh − 280`) and persisted to localStorage. Reuses the file's existing hand-rolled drag pattern — no new dependency.

## Verification
- `go build`, `go vet`, `gofmt -l` — clean
- `go test -race ./internal/...` — pass
- `npm run build` (tsc + vite) — clean
- `npm test` (vitest) — 92/92 pass

## Notes / skipped
- Read-only replica detection left as-is (correct).
- QueryFingerprints' server-side `SortableHeader` was left untouched (different semantics); a new shared client-side one was added instead.