### PR TITLE
Roles overview, icon-only collapsibles, autocomplete on-demand columns

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
-import { Plug, Loader2, AlertCircle, GitCompare, Code, Sun, Moon, Wrench, List, Activity, Fingerprint, Gauge, Menu, X, Network, Layers, FlaskConical, ChevronRight, PanelLeft, PanelLeftClose, GitMerge, Users, BarChart3, TrendingUp, type LucideIcon } from "lucide-react";
+import { Plug, Loader2, AlertCircle, GitCompare, Code, Sun, Moon, Wrench, List, Activity, Fingerprint, Gauge, Menu, X, Network, Layers, FlaskConical, ChevronRight, PanelLeft, PanelLeftClose, GitMerge, Users, BarChart3, TrendingUp, ChevronsUpDown, ChevronsDownUp, type LucideIcon } from "lucide-react";
 import type { ConnectionParams } from "../api/connection";
 import { setConnectionHeaders } from "../api/connection";
 import { testConnection } from "../api/client";
@@ -202,6 +202,16 @@ export function Layout({
 
       {/* Nav sections */}
       <nav className="flex-1 overflow-y-auto overflow-x-hidden px-2 pb-2">
+        {!rail && (
+          <div className="flex justify-end gap-0.5 py-1">
+            <button onClick={() => setCollapsedSections({})} title="Expand all sections" className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]">
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            </button>
+            <button onClick={() => setCollapsedSections(Object.fromEntries(NAV_SECTIONS.map((s) => [s.label, true])))} title="Collapse all sections" className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]">
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
         {NAV_SECTIONS.map((section) => {
           const sectionCollapsed = rail ? false : !!collapsedSections[section.label];
           return (
@@ -225,13 +235,6 @@ export function Layout({
             </div>
           );
         })}
-        {!rail && (
-          <div className="mt-2 flex items-center gap-1 px-2 text-[10px] text-[var(--color-text-secondary)]">
-            <button onClick={() => setCollapsedSections({})} className="rounded px-1.5 py-0.5 hover:bg-[var(--surface-hover)]" title="Expand all sections">Expand all</button>
-            <span className="opacity-40">·</span>
-            <button onClick={() => setCollapsedSections(Object.fromEntries(NAV_SECTIONS.map((s) => [s.label, true])))} className="rounded px-1.5 py-0.5 hover:bg-[var(--surface-hover)]" title="Collapse all sections">Collapse all</button>
-          </div>
-        )}
       </nav>
 
       {/* Bottom cluster: connection + collapse + theme + github */}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -189,6 +189,16 @@ export function Layout({
           </svg>
           {!rail && <span className="text-lg font-semibold text-[var(--color-text-primary)]">ClickLens</span>}
         </NavLink>
+        {!rail && !isMobile && (
+          <div className="ml-auto flex items-center gap-0.5">
+            <button onClick={() => setCollapsedSections({})} title="Expand all sections" className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]">
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            </button>
+            <button onClick={() => setCollapsedSections(Object.fromEntries(NAV_SECTIONS.map((s) => [s.label, true])))} title="Collapse all sections" className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]">
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
         {isMobile && (
           <button
             onClick={() => setMobileMenuOpen(false)}
@@ -202,16 +212,6 @@ export function Layout({
 
       {/* Nav sections */}
       <nav className="flex-1 overflow-y-auto overflow-x-hidden px-2 pb-2">
-        {!rail && (
-          <div className="flex justify-end gap-0.5 py-1">
-            <button onClick={() => setCollapsedSections({})} title="Expand all sections" className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]">
-              <ChevronsUpDown className="h-3.5 w-3.5" />
-            </button>
-            <button onClick={() => setCollapsedSections(Object.fromEntries(NAV_SECTIONS.map((s) => [s.label, true])))} title="Collapse all sections" className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]">
-              <ChevronsDownUp className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
         {NAV_SECTIONS.map((section) => {
           const sectionCollapsed = rail ? false : !!collapsedSections[section.label];
           return (

--- a/web/src/pages/QueryEditor.tsx
+++ b/web/src/pages/QueryEditor.tsx
@@ -190,6 +190,25 @@ export function QueryEditor({ connected }: { connected: boolean }) {
     } catch {}
   }, []);
 
+  // Autocomplete column loader: returns a table's column names, fetching + caching
+  // on demand so columns are offered even for tables never expanded in the sidebar.
+  const colCacheRef = useRef<Map<string, string[]>>(new Map());
+  const ensureColumns = useCallback(async (db: string, table: string): Promise<string[]> => {
+    const key = `${db}.${table}`;
+    const cached = colCacheRef.current.get(key);
+    if (cached) return cached;
+    const existing = schemaData[db]?.tables?.find((t) => t.name === table)?.columns?.map((c) => c.name);
+    if (existing) { colCacheRef.current.set(key, existing); return existing; }
+    try {
+      const res = await fetchColumns(db, table);
+      const names = (res.columns || []).map((c) => c.name);
+      colCacheRef.current.set(key, names);
+      return names;
+    } catch {
+      return [];
+    }
+  }, [schemaData]);
+
   useEffect(() => {
     saveTabs(tabs);
     try { localStorage.setItem("ch-editor-active-tab", activeTab.id); } catch {}
@@ -948,7 +967,7 @@ export function QueryEditor({ connected }: { connected: boolean }) {
               value={sqlText}
               onChange={setSQLText}
               theme={cmTheme}
-              extensions={[cmKeymap, sql(), autocompletion({ override: [makeSqlCompletion(() => buildSQLNamespace() as unknown as SqlNs)] })]}
+              extensions={[cmKeymap, sql(), autocompletion({ override: [makeSqlCompletion(() => buildSQLNamespace() as unknown as SqlNs, ensureColumns)] })]}
               basicSetup={{ lineNumbers: true, foldGutter: false }}
               className="h-full text-sm [&_.cm-editor]:h-full [&_.cm-scroller]:!font-mono [&_.cm-scroller]:text-[13px]"
             />

--- a/web/src/pages/UsersAccess.tsx
+++ b/web/src/pages/UsersAccess.tsx
@@ -16,6 +16,7 @@ import { useTableSort, SortableHeader } from "@/components/ui/table-sort";
 import { EmptyState, ErrorState, NotConnectedState, RefreshIndicator, LoadingNotice } from "@/components/ui/state";
 import { ConfirmDialog } from "@/components/ui/dialog";
 import { Pagination } from "@/components/ui/Pagination";
+import { TimeframeSelector } from "@/components/ui/TimeframeSelector";
 import { formatBytes, formatNumber } from "../utils";
 
 type Tab = "users" | "roles" | "grants" | "quota";
@@ -187,7 +188,7 @@ export function UsersAccess({ connected }: { connected: boolean }) {
               </div>
               {tab === "users" && <UsersRolesTab users={usersF.slice(start, start + pageSize)} canManage={canManage} onDrop={setDropTarget} onRoleClick={showRole} />}
               {tab === "roles" && <RolesTab roles={data.roles} users={data.users} grants={data.grants} focusRole={roleFilter} canManage={canManage} onDrop={setDropTarget} />}
-              {tab === "grants" && <GrantsTab grants={grantsF} canManage={canManage} onRevoke={setRevokeTarget} />}
+              {tab === "grants" && <GrantsTab grants={grantsF} canManage={canManage} onRevoke={setRevokeTarget} onRoleClick={showRole} />}
               {tab === "quota" && <QuotaTab rows={quotaF.slice(start, start + pageSize)} definitions={data.quotas} />}
             </>
             );
@@ -334,43 +335,67 @@ function RolesTab({ roles, users, grants, focusRole, canManage, onDrop }: { role
   );
 }
 
-function GrantsTab({ grants, canManage, onRevoke }: { grants: GrantRow[]; canManage: boolean; onRevoke: (g: GrantRow) => void }) {
-  // Groups are collapsed by default (the list is long); `expanded` holds the
-  // open ones. Hooks run before the empty-state early return.
+function GrantsTab({ grants, canManage, onRevoke, onRoleClick }: { grants: GrantRow[]; canManage: boolean; onRevoke: (g: GrantRow) => void; onRoleClick: (role: string) => void }) {
+  const [groupMode, setGroupMode] = useState<"grantee" | "privilege">("grantee");
+  // `expanded` holds open group keys (grantee names or privilege keys).
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const toggle = (name: string) => setExpanded((prev) => {
+  const toggle = (key: string) => setExpanded((prev) => {
     const next = new Set(prev);
-    if (next.has(name)) next.delete(name); else next.add(name);
+    if (next.has(key)) next.delete(key); else next.add(key);
     return next;
   });
 
   if (grants.length === 0) return <EmptyState icon={KeyRound} title="No grants visible" description="Your user may lack SELECT on system.grants." />;
 
-  // Group by grantee (user or role), preserving first-seen order.
-  const groups = new Map<string, { kind: "user" | "role"; rows: GrantRow[] }>();
+  // ---- Group by grantee (user/role) ----
+  const granteeGroups = new Map<string, { kind: "user" | "role"; rows: GrantRow[] }>();
   for (const g of grants) {
     const name = g.user_name || g.role_name || "";
     const kind = g.user_name ? "user" : "role";
-    let entry = groups.get(name);
-    if (!entry) { entry = { kind, rows: [] }; groups.set(name, entry); }
+    let entry = granteeGroups.get(name);
+    if (!entry) { entry = { kind, rows: [] }; granteeGroups.set(name, entry); }
     entry.rows.push(g);
   }
-  const names = [...groups.keys()];
-  const allExpanded = names.length > 0 && names.every((n) => expanded.has(n));
+  const granteeNames = [...granteeGroups.keys()];
+
+  // ---- Group by privilege (access_type ON object) ----
+  const privKey = (g: GrantRow) => `${g.access_type} ON ${g.database || "*"}.${g.table || "*"}${g.column ? `(${g.column})` : ""}`;
+  const privGroups = new Map<string, { accessType: string; object: string; rows: GrantRow[] }>();
+  for (const g of grants) {
+    const key = privKey(g);
+    let entry = privGroups.get(key);
+    if (!entry) { entry = { accessType: g.access_type, object: `${g.database || "*"}${g.table ? `.${g.table}` : ".*"}${g.column ? ` (${g.column})` : ""}`, rows: [] }; privGroups.set(key, entry); }
+    entry.rows.push(g);
+  }
+  const privKeys = [...privGroups.keys()];
+
+  // Active grouping
+  const groupKeys = groupMode === "grantee" ? granteeNames : privKeys;
+  const allExpanded = groupKeys.length > 0 && groupKeys.every((k) => expanded.has(k));
+  const countLabel = groupMode === "grantee"
+    ? `${granteeNames.length} grantee${granteeNames.length === 1 ? "" : "s"}`
+    : `${privKeys.length} privilege${privKeys.length === 1 ? "" : "s"}`;
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-0.5 text-xs text-[var(--color-text-secondary)]">
-        <button onClick={() => setExpanded(new Set(names))} disabled={allExpanded} className="rounded p-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title="Expand all grantees">
+      <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
+        <TimeframeSelector
+          options={[{ label: "By grantee", value: "grantee" }, { label: "By privilege", value: "privilege" }]}
+          value={groupMode}
+          onChange={(v) => { setGroupMode(v); setExpanded(new Set()); }}
+        />
+        <button onClick={() => setExpanded(new Set(groupKeys))} disabled={allExpanded} className="rounded p-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title={`Expand all ${groupMode === "grantee" ? "grantees" : "privileges"}`}>
           <ChevronsUpDown className="h-3.5 w-3.5" />
         </button>
-        <button onClick={() => setExpanded(new Set())} disabled={expanded.size === 0} className="rounded p-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title="Collapse all grantees">
+        <button onClick={() => setExpanded(new Set())} disabled={expanded.size === 0} className="rounded p-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title="Collapse all">
           <ChevronsDownUp className="h-3.5 w-3.5" />
         </button>
-        <span className="ml-auto">{names.length} grantee{names.length === 1 ? "" : "s"}</span>
+        <span className="ml-auto">{countLabel}</span>
       </div>
-      {names.map((name) => {
-        const { kind, rows } = groups.get(name)!;
+
+      {/* --- By grantee --- */}
+      {groupMode === "grantee" && granteeNames.map((name) => {
+        const { kind, rows } = granteeGroups.get(name)!;
         const open = expanded.has(name);
         return (
           <div key={name} className="rounded-lg border border-[var(--color-border)] bg-[var(--surface-card)]">
@@ -420,6 +445,41 @@ function GrantsTab({ grants, canManage, onRevoke }: { grants: GrantRow[]; canMan
                     ))}
                   </tbody>
                 </table>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* --- By privilege --- */}
+      {groupMode === "privilege" && privKeys.map((key) => {
+        const { accessType, object, rows } = privGroups.get(key)!;
+        const open = expanded.has(key);
+        return (
+          <div key={key} className="rounded-lg border border-[var(--color-border)] bg-[var(--surface-card)]">
+            <button onClick={() => toggle(key)} className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm hover:bg-[var(--surface-hover)]">
+              <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-[var(--color-text-secondary)] transition-transform ${open ? "rotate-90" : ""}`} />
+              <span className="font-mono text-xs text-[var(--color-text-primary)]">{accessType}</span>
+              <span className="font-mono text-xs text-[var(--color-text-secondary)]">on {object}</span>
+              <span className="ml-auto text-xs text-[var(--color-text-secondary)]">{rows.length} grantee{rows.length === 1 ? "" : "s"}</span>
+            </button>
+            {open && (
+              <div className="flex flex-wrap gap-1 border-t border-[var(--color-border)] p-3">
+                {rows.map((g, i) => {
+                  const name = g.user_name || g.role_name || "";
+                  const isUser = !!g.user_name;
+                  return isUser ? (
+                    <Link key={i} to={`/queries?user=${encodeURIComponent(name)}`} title={`Show queries by ${name}`} className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--surface-elevated)] px-2 py-0.5 text-[10px] font-mono text-[var(--color-text-secondary)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]">
+                      <Users className="h-2.5 w-2.5" />{name}
+                      {g.grant_option === 1 && <BadgeCheck className="h-2.5 w-2.5" />}
+                    </Link>
+                  ) : (
+                    <button key={i} onClick={() => onRoleClick(name)} title={`Show role ${name}`} className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--surface-elevated)] px-2 py-0.5 text-[10px] font-mono text-[var(--color-text-secondary)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]">
+                      <KeyRound className="h-2.5 w-2.5" />{name}
+                      {g.grant_option === 1 && <BadgeCheck className="h-2.5 w-2.5" />}
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/web/src/pages/UsersAccess.tsx
+++ b/web/src/pages/UsersAccess.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Link } from "react-router-dom";
-import { RefreshCw, Users, KeyRound, ShieldAlert, Trash2, BadgeCheck, AlertTriangle, Search, ChevronRight } from "lucide-react";
+import { RefreshCw, Users, KeyRound, ShieldAlert, Trash2, BadgeCheck, AlertTriangle, Search, ChevronRight, ChevronsUpDown, ChevronsDownUp } from "lucide-react";
 import { fetchAccess, dropUser, dropRole, revokeGrant } from "../api/client";
 import type { AccessOverview, UserRow, RoleRow, GrantRow, QuotaUsageRow, QuotaDef } from "../api/types";
 import { ApiError } from "../api/errors";
@@ -18,7 +18,7 @@ import { ConfirmDialog } from "@/components/ui/dialog";
 import { Pagination } from "@/components/ui/Pagination";
 import { formatBytes, formatNumber } from "../utils";
 
-type Tab = "users" | "grants" | "quota";
+type Tab = "users" | "roles" | "grants" | "quota";
 type DropTarget = { kind: "user" | "role"; name: string };
 
 export function UsersAccess({ connected }: { connected: boolean }) {
@@ -30,7 +30,9 @@ export function UsersAccess({ connected }: { connected: boolean }) {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
   const [query, setQuery] = useState("");
+  const [roleFilter, setRoleFilter] = useState<string>("");
   const setTab = (t: Tab) => { setTabRaw(t); setPage(1); setQuery(""); };
+  const showRole = (role: string) => { setRoleFilter(role); setTabRaw("roles"); setPage(1); };
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<GrantRow | null>(null);
   const controllerRef = useRef<AbortController | null>(null);
@@ -93,7 +95,8 @@ export function UsersAccess({ connected }: { connected: boolean }) {
   if (error && !data) return <PageContainer><ErrorState error={error} onRetry={load} /></PageContainer>;
 
   const tabs: { id: Tab; label: string; count: number }[] = [
-    { id: "users", label: "Users & Roles", count: (data?.users.length ?? 0) + (data?.roles.length ?? 0) },
+    { id: "users", label: "Users", count: data?.users.length ?? 0 },
+    { id: "roles", label: "Roles", count: data?.roles.length ?? 0 },
     { id: "grants", label: "Grants", count: data?.grants.length ?? 0 },
     { id: "quota", label: "Quota Usage", count: data?.quota_usage.length ?? 0 },
   ];
@@ -182,7 +185,8 @@ export function UsersAccess({ connected }: { connected: boolean }) {
                   <Pagination page={safePage} pageSize={pageSize} total={paged.length} onPage={setPage} onPageSize={(s) => { setPageSize(s); setPage(1); }} />
                 )}
               </div>
-              {tab === "users" && <UsersRolesTab users={usersF.slice(start, start + pageSize)} roles={data.roles} canManage={canManage} onDrop={setDropTarget} />}
+              {tab === "users" && <UsersRolesTab users={usersF.slice(start, start + pageSize)} canManage={canManage} onDrop={setDropTarget} onRoleClick={showRole} />}
+              {tab === "roles" && <RolesTab roles={data.roles} users={data.users} grants={data.grants} focusRole={roleFilter} canManage={canManage} onDrop={setDropTarget} />}
               {tab === "grants" && <GrantsTab grants={grantsF} canManage={canManage} onRevoke={setRevokeTarget} />}
               {tab === "quota" && <QuotaTab rows={quotaF.slice(start, start + pageSize)} definitions={data.quotas} />}
             </>
@@ -217,22 +221,23 @@ export function UsersAccess({ connected }: { connected: boolean }) {
   );
 }
 
-function UsersRolesTab({ users, roles, canManage, onDrop }: { users: UserRow[]; roles: RoleRow[]; canManage: boolean; onDrop: (t: DropTarget) => void }) {
-  if (users.length === 0 && roles.length === 0) {
-    return <EmptyState icon={Users} title="No users or roles visible" description="Your user may lack SELECT on system.users / system.roles." />;
+function UsersRolesTab({ users, canManage, onDrop, onRoleClick }: { users: UserRow[]; canManage: boolean; onDrop: (t: DropTarget) => void; onRoleClick: (role: string) => void }) {
+  if (users.length === 0) {
+    return <EmptyState icon={Users} title="No users visible" description="Your user may lack SELECT on system.users." />;
   }
   return (
-    <div className="space-y-4">
-      <Card className="overflow-hidden">
-        <table className="w-full text-sm">
-          <thead><tr className="border-b border-[var(--color-border)] bg-[var(--surface-elevated)]">
-            <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">User</th>
-            <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Auth</th>
-            <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Default roles</th>
-            <th className="px-4 py-2.5" />
-          </tr></thead>
-          <tbody>
-            {users.map((u: UserRow) => (
+    <Card className="overflow-hidden">
+      <table className="w-full text-sm">
+        <thead><tr className="border-b border-[var(--color-border)] bg-[var(--surface-elevated)]">
+          <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">User</th>
+          <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Auth</th>
+          <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Roles</th>
+          <th className="px-4 py-2.5" />
+        </tr></thead>
+        <tbody>
+          {users.map((u: UserRow) => {
+            const rolesList = u.default_roles ?? [];
+            return (
               <tr key={u.name} className="border-b border-[var(--color-border)] last:border-0">
                 <td className="whitespace-nowrap px-4 py-3">
                   <div className="flex items-center gap-1.5 font-mono text-xs text-[var(--color-text-primary)]">
@@ -244,7 +249,16 @@ function UsersRolesTab({ users, roles, canManage, onDrop }: { users: UserRow[]; 
                   </div>
                 </td>
                 <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-[var(--color-text-secondary)]">{(u.auth_type ?? []).join(", ") || "-"}</td>
-                <td className="px-4 py-3 font-mono text-xs text-[var(--color-text-secondary)]">{(u.default_roles ?? []).join(", ") || "-"}</td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-1">
+                    {rolesList.length === 0 && <span className="text-xs text-[var(--color-text-secondary)]">-</span>}
+                    {rolesList.map((r) => (
+                      <button key={r} onClick={() => onRoleClick(r)} title={`Show role ${r} (members + grants)`} className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--surface-elevated)] px-2 py-0.5 text-[10px] font-mono text-[var(--color-text-secondary)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]">
+                        <KeyRound className="h-2.5 w-2.5" />{r}
+                      </button>
+                    ))}
+                  </div>
+                </td>
                 <td className="px-2 py-3 text-right">
                   {canManage && (
                     <Button variant="ghost" size="sm" onClick={() => onDrop({ kind: "user", name: u.name })} className="text-[var(--color-error)] hover:bg-[var(--state-error)]" title="Drop user">
@@ -253,37 +267,78 @@ function UsersRolesTab({ users, roles, canManage, onDrop }: { users: UserRow[]; 
                   )}
                 </td>
               </tr>
-            ))}
-            {roles.map((r: RoleRow) => (
-              <tr key={`role-${r.name}`} className="border-b border-[var(--color-border)] last:border-0">
-                <td className="whitespace-nowrap px-4 py-3">
-                  <div className="flex items-center gap-1.5 font-mono text-xs text-[var(--color-text-primary)]">
-                    <KeyRound className="h-3 w-3 text-[var(--color-text-secondary)]" /> {r.name}
-                    <Badge variant="default">role</Badge>
+            );
+          })}
+        </tbody>
+      </table>
+    </Card>
+  );
+}
+
+function RolesTab({ roles, users, grants, focusRole, canManage, onDrop }: { roles: RoleRow[]; users: UserRow[]; grants: GrantRow[]; focusRole: string; canManage: boolean; onDrop: (t: DropTarget) => void }) {
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(focusRole ? [focusRole] : []));
+  const toggle = (name: string) => setExpanded((prev) => { const n = new Set(prev); if (n.has(name)) n.delete(name); else n.add(name); return n; });
+
+  if (roles.length === 0) return <EmptyState icon={KeyRound} title="No roles visible" description="Your user may lack SELECT on system.roles." />;
+  return (
+    <div className="space-y-2">
+      {roles.map((r) => {
+        const members = users.filter((u) => (u.default_roles ?? []).includes(r.name));
+        const roleGrants = grants.filter((g) => g.role_name === r.name);
+        const open = expanded.has(r.name);
+        return (
+          <div key={r.name} className="rounded-lg border border-[var(--color-border)] bg-[var(--surface-card)]">
+            <button onClick={() => toggle(r.name)} className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-[var(--surface-hover)]">
+              <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-[var(--color-text-secondary)] transition-transform ${open ? "rotate-90" : ""}`} />
+              <KeyRound className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-secondary)]" />
+              <span className="font-mono text-xs text-[var(--color-text-primary)]">{r.name}</span>
+              <Badge variant="default">{members.length} member{members.length === 1 ? "" : "s"}</Badge>
+              <Badge variant="default">{roleGrants.length} grant{roleGrants.length === 1 ? "" : "s"}</Badge>
+              <span className="ml-auto">
+                {canManage && (
+                  <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onDrop({ kind: "role", name: r.name }); }} className="text-[var(--color-error)] hover:bg-[var(--state-error)]" title="Drop role">
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                )}
+              </span>
+            </button>
+            {open && (
+              <div className="space-y-3 border-t border-[var(--color-border)] p-3">
+                <div>
+                  <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">Members</div>
+                  <div className="flex flex-wrap gap-1">
+                    {members.length === 0 ? <span className="text-xs text-[var(--color-text-secondary)]">no members</span> : members.map((m) => (
+                      <Link key={m.name} to={`/queries?user=${encodeURIComponent(m.name)}`} className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--surface-elevated)] px-2 py-0.5 text-[10px] font-mono text-[var(--color-text-secondary)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]">
+                        <Users className="h-2.5 w-2.5" />{m.name}
+                      </Link>
+                    ))}
                   </div>
-                </td>
-                <td className="px-4 py-3 text-xs text-[var(--color-text-secondary)]">{r.storage}</td>
-                <td className="px-4 py-3" />
-                <td className="px-2 py-3 text-right">
-                  {canManage && (
-                    <Button variant="ghost" size="sm" onClick={() => onDrop({ kind: "role", name: r.name })} className="text-[var(--color-error)] hover:bg-[var(--state-error)]" title="Drop role">
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </Card>
+                </div>
+                <div>
+                  <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">Grants</div>
+                  <div className="space-y-0.5">
+                    {roleGrants.length === 0 ? <span className="text-xs text-[var(--color-text-secondary)]">no grants</span> : roleGrants.map((g, i) => (
+                      <div key={i} className="font-mono text-xs text-[var(--color-text-secondary)]">
+                        <span className="text-[var(--color-text-primary)]">{g.access_type}</span> on {g.database || "*"}{g.table ? `.${g.table}` : ".*"}{g.column ? ` (${g.column})` : ""}
+                        {g.grant_option === 1 && <Badge variant="secondary"><BadgeCheck className="mr-0.5 inline h-3 w-3" />grant option</Badge>}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 function GrantsTab({ grants, canManage, onRevoke }: { grants: GrantRow[]; canManage: boolean; onRevoke: (g: GrantRow) => void }) {
-  // Hooks must run before the empty-state early return.
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  const toggle = (name: string) => setCollapsed((prev) => {
+  // Groups are collapsed by default (the list is long); `expanded` holds the
+  // open ones. Hooks run before the empty-state early return.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (name: string) => setExpanded((prev) => {
     const next = new Set(prev);
     if (next.has(name)) next.delete(name); else next.add(name);
     return next;
@@ -301,19 +356,22 @@ function GrantsTab({ grants, canManage, onRevoke }: { grants: GrantRow[]; canMan
     entry.rows.push(g);
   }
   const names = [...groups.keys()];
-  const allCollapsed = names.length > 0 && names.every((n) => collapsed.has(n));
+  const allExpanded = names.length > 0 && names.every((n) => expanded.has(n));
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
-        <button onClick={() => setCollapsed(new Set())} disabled={collapsed.size === 0} className="rounded px-2 py-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title="Expand all grantees">Expand all</button>
-        <span className="opacity-40">·</span>
-        <button onClick={() => setCollapsed(new Set(names))} disabled={allCollapsed} className="rounded px-2 py-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title="Collapse all grantees">Collapse all</button>
+      <div className="flex items-center gap-0.5 text-xs text-[var(--color-text-secondary)]">
+        <button onClick={() => setExpanded(new Set(names))} disabled={allExpanded} className="rounded p-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title="Expand all grantees">
+          <ChevronsUpDown className="h-3.5 w-3.5" />
+        </button>
+        <button onClick={() => setExpanded(new Set())} disabled={expanded.size === 0} className="rounded p-1 hover:bg-[var(--surface-hover)] disabled:opacity-40" title="Collapse all grantees">
+          <ChevronsDownUp className="h-3.5 w-3.5" />
+        </button>
         <span className="ml-auto">{names.length} grantee{names.length === 1 ? "" : "s"}</span>
       </div>
       {names.map((name) => {
         const { kind, rows } = groups.get(name)!;
-        const open = !collapsed.has(name);
+        const open = expanded.has(name);
         return (
           <div key={name} className="rounded-lg border border-[var(--color-border)] bg-[var(--surface-card)]">
             <button onClick={() => toggle(name)} className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm hover:bg-[var(--surface-hover)]">

--- a/web/src/pages/editor/SchemaSidebar.tsx
+++ b/web/src/pages/editor/SchemaSidebar.tsx
@@ -66,12 +66,12 @@ export function SchemaSidebar({
               className="w-full rounded border border-[var(--color-border)] bg-[var(--surface-base)] py-1 pl-7 pr-2 text-xs text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
             />
           </div>
-          <div className="mb-1 flex items-center justify-end gap-1 px-2 text-[10px] text-[var(--color-text-secondary)]">
-            <button onClick={onExpandAll} className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-[var(--surface-hover)]" title="Expand all databases">
-              <ChevronsUpDown className="h-3 w-3" /> Expand all
+          <div className="mb-1 flex items-center justify-end gap-0.5 px-1">
+            <button onClick={onExpandAll} className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]" title="Expand all databases">
+              <ChevronsUpDown className="h-3.5 w-3.5" />
             </button>
-            <button onClick={onCollapseAll} className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-[var(--surface-hover)]" title="Collapse all">
-              <ChevronsDownUp className="h-3 w-3" /> Collapse all
+            <button onClick={onCollapseAll} className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--color-text-primary)]" title="Collapse all databases">
+              <ChevronsDownUp className="h-3.5 w-3.5" />
             </button>
           </div>
           {visibleDbs.length > 0 ? visibleDbs.map((dbName) => (

--- a/web/src/pages/editor/sqlComplete.test.ts
+++ b/web/src/pages/editor/sqlComplete.test.ts
@@ -61,35 +61,45 @@ describe("makeSqlCompletion", () => {
   // Minimal CompletionContext stand-in: CodeMirror's real ctx has state.doc and pos.
   const ctxAt = (doc: string, pos = doc.length) => source({ state: { doc: { toString: () => doc } }, pos } as never);
 
-  it("offers columns after ORDER BY using the statement's FROM table", () => {
-    const res = ctxAt("select * from mydb.users order by ");
+  it("offers columns after ORDER BY using the statement's FROM table", async () => {
+    const res = await ctxAt("select * from mydb.users order by ");
     expect(res).not.toBeNull();
     const labels = (res!.options as { label: string }[]).map((o) => o.label);
     expect(labels).toEqual(expect.arrayContaining(["id", "name", "email"]));
   });
 
-  it("offers columns in the SELECT list when FROM is present later in the text", () => {
-    const res = ctxAt("select  from mydb.users", "select ".length);
+  it("offers columns in the SELECT list when FROM is present later in the text", async () => {
+    const res = await ctxAt("select  from mydb.users", "select ".length);
     expect(res).not.toBeNull();
     const labels = (res!.options as { label: string }[]).map((o) => o.label);
     expect(labels).toEqual(expect.arrayContaining(["id", "name", "email"]));
   });
 
-  it("offers tables after FROM", () => {
-    const res = ctxAt("select * from ");
+  it("offers tables after FROM", async () => {
+    const res = await ctxAt("select * from ");
     expect(res).not.toBeNull();
     const labels = (res!.options as { label: string }[]).map((o) => o.label);
     expect(labels).toEqual(expect.arrayContaining(["users", "orders", "mydb"]));
   });
 
-  it("offers columns after a db.table. qualifier", () => {
-    const res = ctxAt("select mydb.users.");
+  it("offers columns after a db.table. qualifier", async () => {
+    const res = await ctxAt("select mydb.users.");
     expect(res).not.toBeNull();
     const labels = (res!.options as { label: string }[]).map((o) => o.label);
     expect(labels).toEqual(expect.arrayContaining(["id", "name", "email"]));
   });
 
-  it("returns null inside a string literal", () => {
-    expect(ctxAt("select 'abc")).toBeNull();
+  it("returns null inside a string literal", async () => {
+    expect(await ctxAt("select 'abc")).toBeNull();
+  });
+
+  it("fetches columns on demand for a table not in the namespace", async () => {
+    const unloadedNs: SqlNs = { freshdb: {} as Record<string, string[]> };
+    const ensure = async (_db: string, _t: string) => ["a", "b", "c"];
+    const src = makeSqlCompletion(() => unloadedNs, ensure);
+    const res = await src({ state: { doc: { toString: () => "select  from freshdb.t" } }, pos: "select ".length } as never);
+    expect(res).not.toBeNull();
+    const labels = (res!.options as { label: string }[]).map((o) => o.label);
+    expect(labels).toEqual(expect.arrayContaining(["a", "b", "c"]));
   });
 });

--- a/web/src/pages/editor/sqlComplete.ts
+++ b/web/src/pages/editor/sqlComplete.ts
@@ -33,6 +33,12 @@ export function columnsOfResolved(ns: SqlNs, ref: { db: string; table: string })
   return [];
 }
 
+/** The single database owning `table`, or "" if absent/ambiguous. */
+function dbOfTable(ns: SqlNs, table: string): string {
+  const owners = Object.keys(ns).filter((d) => ns[d] && Object.prototype.hasOwnProperty.call(ns[d], table));
+  return owners.length === 1 ? owners[0] : "";
+}
+
 /**
  * Resolve table references from FROM/JOIN clauses anywhere in `text` (the whole
  * statement, so columns are offered even when the cursor sits before the FROM).
@@ -74,9 +80,16 @@ function allTables(ns: SqlNs): string[] {
  * This source resolves the statement's FROM table(s) and offers their columns
  * in projection/predicate positions, databases/tables after FROM, and columns
  * after a `db.table.` qualifier.
+ *
+ * `ensureColumns` lazily fetches a table's columns when they aren't already in
+ * the namespace (e.g. a table the user never expanded in the sidebar) — without
+ * it, columns are only offered for tables whose columns were pre-loaded.
  */
-export function makeSqlCompletion(getNs: () => SqlNs) {
-  return (ctx: CompletionContext): CompletionResult | null => {
+export function makeSqlCompletion(
+  getNs: () => SqlNs,
+  ensureColumns?: (db: string, table: string) => Promise<string[]>,
+) {
+  return async (ctx: CompletionContext): Promise<CompletionResult | null> => {
     const ns = getNs();
     const doc = ctx.state.doc.toString();
     const before = doc.slice(0, ctx.pos);
@@ -95,7 +108,11 @@ export function makeSqlCompletion(getNs: () => SqlNs) {
       if (ns[qual]) {
         options = Object.keys(ns[qual]).map((t) => ({ label: t, type: "type" }));
       } else {
-        const cols = columnsOfResolved(ns, { db: "", table: qual });
+        let cols = columnsOfResolved(ns, { db: "", table: qual });
+        if (cols.length === 0 && ensureColumns) {
+          const db = dbOfTable(ns, qual);
+          if (db) cols = await ensureColumns(db, qual);
+        }
         options = cols.map((c) => ({ label: c, type: "property" }));
       }
       return options.length ? { from, options, validFor: /^[A-Za-z_]\w*$/ } : null;
@@ -117,11 +134,16 @@ export function makeSqlCompletion(getNs: () => SqlNs) {
       ];
     } else if (COLUMN_KW.has(kw)) {
       // Column position: columns of the FROM table(s), plus the table names
-      // themselves (for qualified refs like table.col).
+      // themselves (for qualified refs like table.col). Columns are fetched
+      // on demand for tables not yet in the namespace.
       const cols = new Set<string>();
       for (const ref of resolveFromTables(doc, ns)) {
         cols.add(ref.table);
-        for (const c of columnsOfResolved(ns, ref)) cols.add(c);
+        let cs = columnsOfResolved(ns, ref);
+        if (cs.length === 0 && ensureColumns && ref.table && ref.db) {
+          cs = await ensureColumns(ref.db, ref.table);
+        }
+        for (const c of cs) cols.add(c);
       }
       options = [...cols].map((c) => ({ label: c, type: "property" }));
     } else {


### PR DESCRIPTION
## Summary

Four UX refinements.

### Roles overview (Users & Access)
- New **Roles** tab: reverse view listing each role with its **member users** and **grants** (collapsible per role).
- User rows now render their roles as **clickable chips** — clicking jumps to that role's detail (members + grants).
- Grants grouping is now **collapsed by default** (the list is long).

### Icon-only collapsibles
- **Schema sidebar** (Databases) and **sidebar nav**: expand/collapse-all are now icon-only buttons with hover tooltips (labels removed).
- Nav expand/collapse-all moved to the **top-right** of the nav area (near the System section).

### Autocomplete column fix
The context-aware completion source now **loads columns on demand** via an `ensureColumns` callback — previously it only offered columns for tables the user had manually expanded in the sidebar, so column suggestions were missing for any other table. Now columns are fetched (and cached) when a FROM table is resolved at completion time. This is the core fix for "won't auto-complete column names."

## Tests
- `npx tsc -b`, `npm test` (**108**), `npm run build` — pass
- `go build`/`vet`/`test ./internal/...` — pass