### PR TITLE
Roles membership fix, page titles, tab URLs, trends polish

### DIFF
--- a/internal/api/query_handlers.go
+++ b/internal/api/query_handlers.go
@@ -62,6 +62,7 @@ func (a *API) ListQueries(w http.ResponseWriter, r *http.Request) {
 		SortDir:           strings.ToUpper(r.URL.Query().Get("sort_dir")),
 		HideSystemQueries: r.URL.Query().Get("hide_system_queries") != "false",
 		IncludeCount:      r.URL.Query().Get("include_count") != "false",
+		ErrorsOnly:        r.URL.Query().Get("errors_only") == "true",
 	}
 	params.FromTime, _ = defaultQueryLogWindow(r)
 

--- a/internal/clickhouse/access.go
+++ b/internal/clickhouse/access.go
@@ -52,6 +52,17 @@ type QuotaUsageRow struct {
 	ExecutionTime float64 `json:"execution_time"`
 }
 
+// RoleGrant is one row of system.role_grants: a role granted to a user or
+// another role. Unlike system.users.default_roles_list (which only covers
+// default roles), this covers ALL role grants — default and non-default — so
+// the Roles tab can show every member.
+type RoleGrant struct {
+	UserName        string `json:"user_name"`
+	GrantedRoleName string `json:"granted_role_name"`
+	IsDefault       uint8  `json:"granted_role_is_default"`
+	WithAdminOption uint8  `json:"with_admin_option"`
+}
+
 // QuotaDef is one row of system.quotas: a quota's configuration (independent of
 // consumption). Shown so the usage rows can be tied back to the quota that
 // defines the limits and window.
@@ -74,6 +85,7 @@ type AccessOverview struct {
 	Users               []UserRow         `json:"users"`
 	Roles               []RoleRow         `json:"roles"`
 	Grants              []GrantRow        `json:"grants"`
+	RoleGrants          []RoleGrant       `json:"role_grants"`
 	Quotas              []QuotaDef        `json:"quotas"`
 	QuotaUsage          []QuotaUsageRow   `json:"quota_usage"`
 	PartialErrors       []string          `json:"partial_errors"`
@@ -97,13 +109,14 @@ func (a *AccessOverview) addPartial(table string, err error) {
 // whether the UI offers destructive actions; every manage call is still
 // validated server-side (the probe can be wrong or privileges partial).
 func (c *Client) GetAccess(ctx context.Context) (*AccessOverview, error) {
-	out := &AccessOverview{Users: []UserRow{}, Roles: []RoleRow{}, Grants: []GrantRow{}, Quotas: []QuotaDef{}, QuotaUsage: []QuotaUsageRow{}}
+	out := &AccessOverview{Users: []UserRow{}, Roles: []RoleRow{}, Grants: []GrantRow{}, RoleGrants: []RoleGrant{}, Quotas: []QuotaDef{}, QuotaUsage: []QuotaUsageRow{}}
 
 	c.queryCurrentUser(ctx, out)
 	c.queryAccessCapability(ctx, out)
 	c.queryUsers(ctx, out)
 	c.queryRoles(ctx, out)
 	c.queryGrants(ctx, out)
+	c.queryRoleGrants(ctx, out)
 	c.queryQuotas(ctx, out)
 	c.queryQuotaUsage(ctx, out)
 
@@ -193,6 +206,27 @@ func (c *Client) queryGrants(ctx context.Context, out *AccessOverview) {
 			return
 		}
 		out.Grants = append(out.Grants, g)
+	}
+}
+
+func (c *Client) queryRoleGrants(ctx context.Context, out *AccessOverview) {
+	const q = `SELECT assumeNotNull(user_name), granted_role_name, granted_role_is_default, with_admin_option
+		FROM system.role_grants
+		WHERE user_name IS NOT NULL
+		ORDER BY granted_role_name, user_name`
+	rows, err := c.conn.Query(ctx, q)
+	if err != nil {
+		out.addPartial("system.role_grants", err)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rg RoleGrant
+		if err := rows.Scan(&rg.UserName, &rg.GrantedRoleName, &rg.IsDefault, &rg.WithAdminOption); err != nil {
+			out.addPartial("system.role_grants", err)
+			return
+		}
+		out.RoleGrants = append(out.RoleGrants, rg)
 	}
 }
 

--- a/internal/clickhouse/query_log.go
+++ b/internal/clickhouse/query_log.go
@@ -53,6 +53,7 @@ type QueryListParams struct {
 	MinDuration       uint64 `json:"min_duration"`
 	MinMemory         uint64 `json:"min_memory"`
 	MinReadBytes      uint64 `json:"min_read_bytes"`
+	ErrorsOnly        bool   `json:"errors_only"`
 	Search            string `json:"search"`
 	SortBy            string `json:"sort_by"`
 	SortDir           string `json:"sort_dir"`
@@ -158,6 +159,9 @@ func (c *Client) ListQueries(ctx context.Context, params QueryListParams) ([]Que
 	if params.MinReadBytes > 0 {
 		whereParts = append(whereParts, "read_bytes >= ?")
 		whereArgs = append(whereArgs, params.MinReadBytes)
+	}
+	if params.ErrorsOnly {
+		whereParts = append(whereParts, "exception_code != 0")
 	}
 
 	allowedSorts := map[string]bool{

--- a/internal/clickhouse/query_log.go
+++ b/internal/clickhouse/query_log.go
@@ -232,12 +232,34 @@ func (c *Client) ListQueries(ctx context.Context, params QueryListParams) ([]Que
 }
 
 func (c *Client) GetQuery(ctx context.Context, queryID string) (*QueryLogEntry, error) {
+	// Retry loop: after a query finishes there is a window (up to
+	// flush_interval_milliseconds, ~7.5s default) where the row has left
+	// system.processes but hasn't been flushed to query_log yet. In that gap
+	// neither source has the row. We retry once after 2s — by then the flush
+	// has usually landed. The common cases (still running → processes, or
+	// already flushed → query_log) return immediately on the first attempt.
+	for attempt := 0; attempt < 2; attempt++ {
+		entry, retryable, err := c.getQueryOnce(ctx, queryID)
+		if err == nil {
+			return entry, nil
+		}
+		if !retryable || attempt == 1 {
+			return nil, err
+		}
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return nil, NotFoundErrorf("query %s", queryID)
+}
+
+// getQueryOnce is a single attempt: terminal query_log → system.processes
+// fallback. Returns (nil, true, err) when neither source has the row and a
+// retry might help (the race window).
+func (c *Client) getQueryOnce(ctx context.Context, queryID string) (*QueryLogEntry, bool, error) {
 	table := c.tableRef("query_log")
-	// Filter to terminal types: ProfileEvents/Settings are only populated on
-	// QueryFinish / Exception* rows, not QueryStart. QueryStart and QueryFinish
-	// share the same event_time, so ORDER BY event_time DESC LIMIT 1 alone can
-	// non-deterministically return the empty QueryStart row (the cause of "all
-	// compared metrics are 0" on the compare page).
 	query := fmt.Sprintf(`SELECT
 		type, event_time, query_start_time, query_duration_ms, query_id, query,
 		normalized_query_hash, query_kind, user,
@@ -261,25 +283,23 @@ func (c *Client) GetQuery(ctx context.Context, queryID string) (*QueryLogEntry, 
 		&e.IsInitialQuery, &e.InitialQueryID, &e.Settings, &e.ProfileEvents,
 		&e.UsedFunctions, &e.UsedStorages, &e.UsedAggregateFunctions,
 	); err != nil {
-		// No terminal query_log row: query_log rows are written on completion,
-		// so a still-running query has none yet. Fall back to system.processes
-		// (the live view) so opening a running query from the Running page does
-		// not 404. ProfileEvents/Settings/result-counts are unavailable live
-		// and stay empty — those tabs populate once the query finishes.
 		if !errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("querying query_log for %s: %w", queryID, err)
+			return nil, false, fmt.Errorf("querying query_log for %s: %w", queryID, err)
 		}
+		// No terminal query_log row yet. Try system.processes (still running).
 		proc, perr := c.GetProcess(ctx, queryID)
 		if perr != nil {
 			if errors.Is(perr, ErrNotFound) {
-				return nil, NotFoundErrorf("query %s", queryID)
+				// Neither source has the row — likely the race window (query
+				// just finished, query_log flush pending). Signal retryable.
+				return nil, true, NotFoundErrorf("query %s", queryID)
 			}
-			return nil, perr
+			return nil, false, perr
 		}
-		return processToEntry(proc), nil
+		return processToEntry(proc), false, nil
 	}
 	e.NormalizedQueryHash = strconv.FormatUint(hash, 10)
-	return &e, nil
+	return &e, false, nil
 }
 
 // processToEntry synthesizes a QueryLogEntry from a live system.processes row,

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -171,6 +171,7 @@ export interface QueryListParams {
   min_duration?: number;
   min_memory?: number;
   min_read_bytes?: number;
+  errors_only?: boolean;
   search?: string;
   sort_by?: string;
   sort_dir?: string;
@@ -338,6 +339,13 @@ export interface RoleRow {
   storage: string;
 }
 
+export interface RoleGrant {
+  user_name: string;
+  granted_role_name: string;
+  granted_role_is_default: number;
+  with_admin_option: number;
+}
+
 export interface GrantRow {
   user_name: string;
   role_name: string;
@@ -380,6 +388,7 @@ export interface AccessOverview {
   users: UserRow[];
   roles: RoleRow[];
   grants: GrantRow[];
+  role_grants: RoleGrant[];
   quotas: QuotaDef[];
   quota_usage: QuotaUsageRow[];
   partial_errors: string[];

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -51,6 +51,24 @@ const NAV_SECTIONS: NavSectionDef[] = [
   },
 ];
 
+// Route → browser-tab title. Dynamic routes use prefix matching in the effect.
+const PAGE_TITLES: Record<string, string> = {
+  "/": "Dashboard",
+  "/queries": "Queries",
+  "/running": "Running Queries",
+  "/fingerprints": "Fingerprints",
+  "/replication": "Replication",
+  "/ddl": "DDL",
+  "/mutations": "Mutations",
+  "/merges": "Merges",
+  "/system-metrics": "System Metrics",
+  "/trends": "Trends",
+  "/access": "Users & Access",
+  "/optimizer": "Table Optimizer",
+  "/editor": "SQL Editor",
+  "/compare": "Query Comparison",
+};
+
 export function Layout({
   connection,
   connected,
@@ -76,6 +94,20 @@ export function Layout({
   const [cluster, setCluster] = useState<string>("");
   const [clusterNote, setClusterNote] = useState<string>("");
   const location = useLocation();
+
+  // Set the browser tab title from the route + active tab param.
+  useEffect(() => {
+    const path = location.pathname;
+    let title = PAGE_TITLES[path];
+    if (!title) {
+      if (path.startsWith("/query/")) title = "Query Detail";
+      else if (path.startsWith("/fingerprints/")) title = "Fingerprint Detail";
+      else title = "ClickLens";
+    }
+    const tab = new URLSearchParams(location.search).get("tab");
+    if (tab) title += ` \u2014 ${tab.charAt(0).toUpperCase()}${tab.slice(1)}`;
+    document.title = `${title} \u2014 ClickLens`;
+  }, [location.pathname, location.search]);
 
   useEffect(() => { try { localStorage.setItem("ch-nav-collapsed", collapsed ? "1" : "0"); } catch {} }, [collapsed]);
   useEffect(() => { try { localStorage.setItem("ch-nav-sections", JSON.stringify(collapsedSections)); } catch {} }, [collapsedSections]);

--- a/web/src/pages/QueryFingerprints.tsx
+++ b/web/src/pages/QueryFingerprints.tsx
@@ -177,11 +177,6 @@ export function QueryFingerprints({ connected }: { connected: boolean }) {
           <Filter className="h-3.5 w-3.5" />
           Filters
         </Button>
-        <Checkbox
-          checked={showSystem}
-          onChange={(e) => { setShowSystem(e.target.checked); setCurrentPage(1); }}
-          label="Internal queries"
-        />
       </div>
 
       {showFilters && (
@@ -222,6 +217,13 @@ export function QueryFingerprints({ connected }: { connected: boolean }) {
                 className="w-full"
               />
             </div>
+          </div>
+          <div className="mt-3">
+            <Checkbox
+              checked={showSystem}
+              onChange={(e) => { setShowSystem(e.target.checked); setCurrentPage(1); }}
+              label="Internal queries"
+            />
           </div>
         </Card>
       )}

--- a/web/src/pages/QueryList.tsx
+++ b/web/src/pages/QueryList.tsx
@@ -60,6 +60,7 @@ export function QueryList({ connected }: { connected: boolean }) {
     min_duration: Number(urlParam("min_duration")) || undefined,
     min_memory: Number(urlParam("min_memory")) || undefined,
     min_read_bytes: Number(urlParam("min_read_bytes")) || undefined,
+    errors_only: urlParam("errors_only") === "true",
   });
   const [search, setSearch] = useState(urlParam("q"));
   const [showFilters, setShowFilters] = useState(false);
@@ -80,6 +81,7 @@ export function QueryList({ connected }: { connected: boolean }) {
     if (params.min_duration) sp.set("min_duration", String(params.min_duration));
     if (params.min_memory) sp.set("min_memory", String(params.min_memory));
     if (params.min_read_bytes) sp.set("min_read_bytes", String(params.min_read_bytes));
+    if (params.errors_only) sp.set("errors_only", "true");
     if (!params.hide_system_queries) sp.set("hide_system", "false");
     setSearchParams(sp, { replace: true });
   }, [search, params, setSearchParams]);
@@ -213,7 +215,7 @@ export function QueryList({ connected }: { connected: boolean }) {
         />
       </div>
 
-      {(params.user || params.database || params.table) && (
+      {(params.user || params.database || params.table || params.errors_only) && (
         <div className="mb-2 flex flex-wrap items-center gap-1.5">
           <span className="text-xs text-[var(--color-text-secondary)]">Filtered by:</span>
           {params.user && (
@@ -224,6 +226,9 @@ export function QueryList({ connected }: { connected: boolean }) {
           )}
           {params.table && (
             <Chip onClear={() => setParams((p) => ({ ...p, table: undefined, offset: 0 }))} label={`table: ${params.table}`} />
+          )}
+          {params.errors_only && (
+            <Chip onClear={() => setParams((p) => ({ ...p, errors_only: false, offset: 0 }))} label="failed only" />
           )}
         </div>
       )}

--- a/web/src/pages/QueryList.tsx
+++ b/web/src/pages/QueryList.tsx
@@ -213,6 +213,11 @@ export function QueryList({ connected }: { connected: boolean }) {
           }}
           label="Internal queries"
         />
+        <Checkbox
+          checked={!!params.errors_only}
+          onChange={(e) => setParams((p) => ({ ...p, errors_only: e.target.checked, offset: 0 }))}
+          label="Failed only"
+        />
       </div>
 
       {(params.user || params.database || params.table || params.errors_only) && (

--- a/web/src/pages/QueryList.tsx
+++ b/web/src/pages/QueryList.tsx
@@ -205,19 +205,6 @@ export function QueryList({ connected }: { connected: boolean }) {
           <Filter className="h-3.5 w-3.5" />
           Filters
         </Button>
-        <Checkbox
-          checked={showSystem}
-          onChange={(e) => {
-            setShowSystem(e.target.checked);
-            setParams((p) => ({ ...p, hide_system_queries: !e.target.checked, offset: 0 }));
-          }}
-          label="Internal queries"
-        />
-        <Checkbox
-          checked={!!params.errors_only}
-          onChange={(e) => setParams((p) => ({ ...p, errors_only: e.target.checked, offset: 0 }))}
-          label="Failed only"
-        />
       </div>
 
       {(params.user || params.database || params.table || params.errors_only) && (
@@ -314,6 +301,21 @@ export function QueryList({ connected }: { connected: boolean }) {
                 <option value="ASC">Ascending</option>
               </Select>
             </div>
+          </div>
+          <div className="mt-3 flex items-center gap-4">
+            <Checkbox
+              checked={showSystem}
+              onChange={(e) => {
+                setShowSystem(e.target.checked);
+                setParams((p) => ({ ...p, hide_system_queries: !e.target.checked, offset: 0 }));
+              }}
+              label="Internal queries"
+            />
+            <Checkbox
+              checked={!!params.errors_only}
+              onChange={(e) => setParams((p) => ({ ...p, errors_only: e.target.checked, offset: 0 }))}
+              label="Failed only"
+            />
           </div>
         </Card>
       )}

--- a/web/src/pages/RunningQueries.tsx
+++ b/web/src/pages/RunningQueries.tsx
@@ -343,16 +343,6 @@ export function RunningQueries({ connected }: { connected: boolean }) {
           <Filter className="h-3.5 w-3.5" />
           Filters
         </Button>
-        <Checkbox
-          checked={showSystem}
-          onChange={(e) => setShowSystem(e.target.checked)}
-          label="Internal queries"
-        />
-        <Checkbox
-          checked={groupByUser}
-          onChange={(e) => setGroupByUser(e.target.checked)}
-          label="Group by user"
-        />
         {filtered.length > 0 && (
           <Badge variant="default">{filtered.length} running</Badge>
         )}
@@ -375,6 +365,18 @@ export function RunningQueries({ connected }: { connected: boolean }) {
                 {QUERY_KINDS.map((k) => <option key={k} value={k}>{k}</option>)}
               </Select>
             </div>
+          </div>
+          <div className="mt-3 flex items-center gap-4">
+            <Checkbox
+              checked={showSystem}
+              onChange={(e) => setShowSystem(e.target.checked)}
+              label="Internal queries"
+            />
+            <Checkbox
+              checked={groupByUser}
+              onChange={(e) => setGroupByUser(e.target.checked)}
+              label="Group by user"
+            />
           </div>
         </Card>
       )}

--- a/web/src/pages/Trends.tsx
+++ b/web/src/pages/Trends.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { RefreshCw, TrendingUp } from "lucide-react";
+import { Link } from "react-router-dom";
+import { RefreshCw, TrendingUp, ExternalLink } from "lucide-react";
 import { AreaChart, Area, LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { fetchQueryHealthTrend } from "../api/client";
 import type { QueryHealthPoint } from "../api/types";
@@ -10,13 +11,15 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { EmptyState, ErrorState, NotConnectedState, RefreshIndicator, LoadingNotice } from "@/components/ui/state";
 import { TimeframeSelector } from "@/components/ui/TimeframeSelector";
-import { formatNumber } from "../utils";
+import { formatBytes } from "../utils";
 
 const fmtBucket = (b: unknown) => {
   const s = String(b ?? "");
   const d = new Date(s.replace(" ", "T"));
   return isNaN(d.getTime()) ? s : d.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
 };
+
+const BUCKET_LABEL: Record<number, string> = { 1: "5 min", 24: "1 hour", 168: "6 hours" };
 
 export function Trends({ connected }: { connected: boolean }) {
   const [data, setData] = useState<QueryHealthPoint[]>([]);
@@ -26,6 +29,8 @@ export function Trends({ connected }: { connected: boolean }) {
   const [canceled, setCanceled] = useState(false);
   const controllerRef = useRef<AbortController | null>(null);
   const elapsed = useElapsedTimer(loading);
+  const bucketLabel = BUCKET_LABEL[hours] ?? "1 hour";
+  const fromTime = new Date(Date.now() - hours * 3600 * 1000).toISOString().replace("T", " ").slice(0, 19);
 
   const load = useCallback(async (h: number) => {
     setCanceled(false);
@@ -78,6 +83,7 @@ export function Trends({ connected }: { connected: boolean }) {
           value={hours}
           onChange={setHours}
         />
+        <span className="text-xs text-[var(--color-text-secondary)] opacity-70">bucket size: {bucketLabel}</span>
       </div>
 
       {error && data.length > 0 && <div className="mb-4"><ErrorState error={error} onRetry={() => load(hours)} /></div>}
@@ -90,7 +96,7 @@ export function Trends({ connected }: { connected: boolean }) {
         <EmptyState icon={TrendingUp} title="No query data in this window" description="No queries logged in the selected timeframe." />
       ) : (
         <div className="grid gap-4 lg:grid-cols-2">
-          <ChartCard title="Queries / bucket">
+          <ChartCard title={`Queries (${bucketLabel} buckets)`} description="Completed user queries per bucket. Volume = throughput." drillTo={`/queries?from_time=${encodeURIComponent(fromTime)}`}>
             <ResponsiveContainer width="100%" height={220}>
               <AreaChart data={data}>
                 <defs><linearGradient id="gCount" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="var(--color-accent)" stopOpacity={0.4} /><stop offset="95%" stopColor="var(--color-accent)" stopOpacity={0} /></linearGradient></defs>
@@ -103,7 +109,7 @@ export function Trends({ connected }: { connected: boolean }) {
             </ResponsiveContainer>
           </ChartCard>
 
-          <ChartCard title="Latency p50 / p95 (ms)">
+          <ChartCard title="Latency p50 / p95 (ms)" description="50th / 95th percentile query duration. p95 spikes = tail-latency outliers." drillTo={`/queries?from_time=${encodeURIComponent(fromTime)}`}>
             <ResponsiveContainer width="100%" height={220}>
               <LineChart data={data}>
                 <XAxis dataKey="bucket" tickFormatter={fmtBucket} tick={{ fontSize: 10 }} minTickGap={40} />
@@ -116,7 +122,7 @@ export function Trends({ connected }: { connected: boolean }) {
             </ResponsiveContainer>
           </ChartCard>
 
-          <ChartCard title="Errors / bucket">
+          <ChartCard title={`Errors (${bucketLabel} buckets)`} description="Queries that failed with an exception. Click → to investigate." drillTo={`/queries?from_time=${encodeURIComponent(fromTime)}&errors_only=true`}>
             <ResponsiveContainer width="100%" height={220}>
               <BarChart data={data}>
                 <XAxis dataKey="bucket" tickFormatter={fmtBucket} tick={{ fontSize: 10 }} minTickGap={40} />
@@ -128,14 +134,14 @@ export function Trends({ connected }: { connected: boolean }) {
             </ResponsiveContainer>
           </ChartCard>
 
-          <ChartCard title="Avg memory / bucket (bytes)">
+          <ChartCard title={`Avg memory (${bucketLabel} buckets)`} description="Average peak memory per query. Spikes = memory-heavy workload." drillTo={`/queries?from_time=${encodeURIComponent(fromTime)}`}>
             <ResponsiveContainer width="100%" height={220}>
               <AreaChart data={data}>
                 <defs><linearGradient id="gMem" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="var(--color-accent)" stopOpacity={0.4} /><stop offset="95%" stopColor="var(--color-accent)" stopOpacity={0} /></linearGradient></defs>
                 <XAxis dataKey="bucket" tickFormatter={fmtBucket} tick={{ fontSize: 10 }} minTickGap={40} />
-                <YAxis tick={{ fontSize: 10 }} tickFormatter={(v) => formatNumber(v)} />
+                <YAxis tick={{ fontSize: 10 }} tickFormatter={(v) => formatBytes(v)} />
                 <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
-                <Tooltip labelFormatter={fmtBucket} />
+                <Tooltip labelFormatter={fmtBucket} formatter={(v: unknown) => [formatBytes(Number(v)), "avg memory"]} />
                 <Area type="monotone" dataKey="avg_memory" name="avg memory" stroke="var(--color-accent)" fill="url(#gMem)" />
               </AreaChart>
             </ResponsiveContainer>
@@ -146,10 +152,20 @@ export function Trends({ connected }: { connected: boolean }) {
   );
 }
 
-function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+function ChartCard({ title, description, drillTo, children }: { title: string; description: string; drillTo?: string; children: React.ReactNode }) {
   return (
     <Card className="p-4">
-      <div className="mb-2 text-xs font-medium text-[var(--color-text-secondary)]">{title}</div>
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <div>
+          <div className="text-xs font-medium text-[var(--color-text-secondary)]">{title}</div>
+          <div className="text-[10px] text-[var(--color-text-secondary)] opacity-70">{description}</div>
+        </div>
+        {drillTo && (
+          <Link to={drillTo} title="View queries in this timeframe" className="shrink-0 rounded p-1 text-[var(--color-accent)] hover:bg-[var(--surface-hover)]">
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        )}
+      </div>
       {children}
     </Card>
   );

--- a/web/src/pages/UsersAccess.tsx
+++ b/web/src/pages/UsersAccess.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { RefreshCw, Users, KeyRound, ShieldAlert, Trash2, BadgeCheck, AlertTriangle, Search, ChevronRight, ChevronsUpDown, ChevronsDownUp } from "lucide-react";
 import { fetchAccess, dropUser, dropRole, revokeGrant } from "../api/client";
-import type { AccessOverview, UserRow, RoleRow, GrantRow, QuotaUsageRow, QuotaDef } from "../api/types";
+import type { AccessOverview, UserRow, RoleRow, GrantRow, RoleGrant, QuotaUsageRow, QuotaDef } from "../api/types";
 import { ApiError } from "../api/errors";
 import { useToast } from "../components/Toast";
 import { useElapsedTimer } from "@/hooks/useElapsedTimer";
@@ -27,13 +27,19 @@ export function UsersAccess({ connected }: { connected: boolean }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<ApiError | null>(null);
   const [canceled, setCanceled] = useState(false);
-  const [tab, setTabRaw] = useState<Tab>("users");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [tab, setTabRaw] = useState<Tab>((searchParams.get("tab") as Tab) || "users");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
   const [query, setQuery] = useState("");
   const [roleFilter, setRoleFilter] = useState<string>("");
-  const setTab = (t: Tab) => { setTabRaw(t); setPage(1); setQuery(""); };
-  const showRole = (role: string) => { setRoleFilter(role); setTabRaw("roles"); setPage(1); };
+  const syncTab = (t: Tab) => {
+    const next = new URLSearchParams();
+    if (t !== "users") next.set("tab", t);
+    setSearchParams(next, { replace: true });
+  };
+  const setTab = (t: Tab) => { setTabRaw(t); setPage(1); setQuery(""); syncTab(t); };
+  const showRole = (role: string) => { setRoleFilter(role); setTabRaw("roles"); setPage(1); syncTab("roles"); };
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<GrantRow | null>(null);
   const controllerRef = useRef<AbortController | null>(null);
@@ -187,7 +193,7 @@ export function UsersAccess({ connected }: { connected: boolean }) {
                 )}
               </div>
               {tab === "users" && <UsersRolesTab users={usersF.slice(start, start + pageSize)} canManage={canManage} onDrop={setDropTarget} onRoleClick={showRole} />}
-              {tab === "roles" && <RolesTab roles={data.roles} users={data.users} grants={data.grants} focusRole={roleFilter} canManage={canManage} onDrop={setDropTarget} />}
+              {tab === "roles" && <RolesTab roles={data.roles} grants={data.grants} roleGrants={data.role_grants} focusRole={roleFilter} canManage={canManage} onDrop={setDropTarget} />}
               {tab === "grants" && <GrantsTab grants={grantsF} canManage={canManage} onRevoke={setRevokeTarget} onRoleClick={showRole} />}
               {tab === "quota" && <QuotaTab rows={quotaF.slice(start, start + pageSize)} definitions={data.quotas} />}
             </>
@@ -276,7 +282,7 @@ function UsersRolesTab({ users, canManage, onDrop, onRoleClick }: { users: UserR
   );
 }
 
-function RolesTab({ roles, users, grants, focusRole, canManage, onDrop }: { roles: RoleRow[]; users: UserRow[]; grants: GrantRow[]; focusRole: string; canManage: boolean; onDrop: (t: DropTarget) => void }) {
+function RolesTab({ roles, grants, roleGrants, focusRole, canManage, onDrop }: { roles: RoleRow[]; grants: GrantRow[]; roleGrants: RoleGrant[]; focusRole: string; canManage: boolean; onDrop: (t: DropTarget) => void }) {
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(focusRole ? [focusRole] : []));
   const toggle = (name: string) => setExpanded((prev) => { const n = new Set(prev); if (n.has(name)) n.delete(name); else n.add(name); return n; });
 
@@ -284,8 +290,8 @@ function RolesTab({ roles, users, grants, focusRole, canManage, onDrop }: { role
   return (
     <div className="space-y-2">
       {roles.map((r) => {
-        const members = users.filter((u) => (u.default_roles ?? []).includes(r.name));
-        const roleGrants = grants.filter((g) => g.role_name === r.name);
+        const members = roleGrants.filter((rg) => rg.granted_role_name === r.name);
+        const roleGrantRows = grants.filter((g) => g.role_name === r.name);
         const open = expanded.has(r.name);
         return (
           <div key={r.name} className="rounded-lg border border-[var(--color-border)] bg-[var(--surface-card)]">
@@ -294,7 +300,7 @@ function RolesTab({ roles, users, grants, focusRole, canManage, onDrop }: { role
               <KeyRound className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-secondary)]" />
               <span className="font-mono text-xs text-[var(--color-text-primary)]">{r.name}</span>
               <Badge variant="default">{members.length} member{members.length === 1 ? "" : "s"}</Badge>
-              <Badge variant="default">{roleGrants.length} grant{roleGrants.length === 1 ? "" : "s"}</Badge>
+              <Badge variant="default">{roleGrantRows.length} grant{roleGrantRows.length === 1 ? "" : "s"}</Badge>
               <span className="ml-auto">
                 {canManage && (
                   <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onDrop({ kind: "role", name: r.name }); }} className="text-[var(--color-error)] hover:bg-[var(--state-error)]" title="Drop role">
@@ -309,8 +315,9 @@ function RolesTab({ roles, users, grants, focusRole, canManage, onDrop }: { role
                   <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">Members</div>
                   <div className="flex flex-wrap gap-1">
                     {members.length === 0 ? <span className="text-xs text-[var(--color-text-secondary)]">no members</span> : members.map((m) => (
-                      <Link key={m.name} to={`/queries?user=${encodeURIComponent(m.name)}`} className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--surface-elevated)] px-2 py-0.5 text-[10px] font-mono text-[var(--color-text-secondary)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]">
-                        <Users className="h-2.5 w-2.5" />{m.name}
+                      <Link key={m.user_name} to={`/queries?user=${encodeURIComponent(m.user_name)}`} className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--surface-elevated)] px-2 py-0.5 text-[10px] font-mono text-[var(--color-text-secondary)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]" title={m.granted_role_is_default === 1 ? "Default role" : "Granted (not default)"}>
+                        <Users className="h-2.5 w-2.5" />{m.user_name}
+                        {m.granted_role_is_default === 0 && <span className="opacity-60">●</span>}
                       </Link>
                     ))}
                   </div>
@@ -318,7 +325,7 @@ function RolesTab({ roles, users, grants, focusRole, canManage, onDrop }: { role
                 <div>
                   <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">Grants</div>
                   <div className="space-y-0.5">
-                    {roleGrants.length === 0 ? <span className="text-xs text-[var(--color-text-secondary)]">no grants</span> : roleGrants.map((g, i) => (
+                    {roleGrantRows.length === 0 ? <span className="text-xs text-[var(--color-text-secondary)]">no grants</span> : roleGrantRows.map((g, i) => (
                       <div key={i} className="font-mono text-xs text-[var(--color-text-secondary)]">
                         <span className="text-[var(--color-text-primary)]">{g.access_type}</span> on {g.database || "*"}{g.table ? `.${g.table}` : ".*"}{g.column ? ` (${g.column})` : ""}
                         {g.grant_option === 1 && <Badge variant="secondary"><BadgeCheck className="mr-0.5 inline h-3 w-3" />grant option</Badge>}


### PR DESCRIPTION
## Summary

Six improvements bundled.

### 1. Roles membership fix (the reported bug)
Roles showed 0 members because membership was computed from `default_roles_list` only (roles set as default). Now queries **`system.role_grants`** which covers ALL role grants — default and non-default. Non-default members are marked with a dot (●) + tooltip.

### 2. Page titles
Route-to-title `useEffect` in Layout sets `document.title` per page + active tab (`?tab=`) — e.g. `"Users & Access — Roles — ClickLens"`. Handles all 16 pages + dynamic routes (`/query/:id`, `/fingerprints/:hash`). One file, no per-page changes.

### 3. Tab in URL for Users & Access
`?tab=roles` / `?tab=grants` / `?tab=quota` now syncs to the URL (shareable, bookmarkable). QueryDetail already had this.

### 4. Trends bucket size label
The bucket interval is displayed next to the timeframe selector: `1h → "5 min"`, `24h → "1 hour"`, `7d → "6 hours"`. Also appended to chart card titles.

### 5. Avg memory formatting
The avg-memory YAxis + Tooltip now use `formatBytes` (e.g. `128.0 MB`) instead of raw numbers (`134217728`).

### 6. Trends descriptions + drill-down links
Each chart card has a **one-line description** explaining what it shows and what a spike means. Each card has a **drill-down icon** (→) linking to the Query List filtered by the timeframe:
- Errors chart links with `errors_only=true` (new backend filter: `exception_code != 0`).
- Query List shows a **"failed only"** chip when errors_only is active.

## Tests / verify
- `go build`/`vet`/`test ./internal/...` — pass
- `npx tsc -b`, `npm test` (108), `npm run build` — pass