### PR TITLE
Add log_comment filter; scrollable SQL editor result cells

### DIFF
--- a/internal/api/query_handlers.go
+++ b/internal/api/query_handlers.go
@@ -63,6 +63,7 @@ func (a *API) ListQueries(w http.ResponseWriter, r *http.Request) {
 		HideSystemQueries: r.URL.Query().Get("hide_system_queries") != "false",
 		IncludeCount:      r.URL.Query().Get("include_count") != "false",
 		ErrorsOnly:        r.URL.Query().Get("errors_only") == "true",
+		LogComment:        r.URL.Query().Get("log_comment"),
 	}
 	params.FromTime, _ = defaultQueryLogWindow(r)
 
@@ -536,6 +537,7 @@ func (a *API) ListFingerprints(w http.ResponseWriter, r *http.Request) {
 		SortDir:           strings.ToUpper(r.URL.Query().Get("sort_dir")),
 		HideSystemQueries: r.URL.Query().Get("hide_system_queries") != "false",
 		IncludeCount:      r.URL.Query().Get("include_count") != "false",
+		LogComment:        r.URL.Query().Get("log_comment"),
 	}
 	params.FromTime, _ = defaultQueryLogWindow(r)
 

--- a/internal/clickhouse/query_log.go
+++ b/internal/clickhouse/query_log.go
@@ -54,6 +54,7 @@ type QueryListParams struct {
 	MinMemory         uint64 `json:"min_memory"`
 	MinReadBytes      uint64 `json:"min_read_bytes"`
 	ErrorsOnly        bool   `json:"errors_only"`
+	LogComment        string `json:"log_comment"`
 	Search            string `json:"search"`
 	SortBy            string `json:"sort_by"`
 	SortDir           string `json:"sort_dir"`
@@ -162,6 +163,10 @@ func (c *Client) ListQueries(ctx context.Context, params QueryListParams) ([]Que
 	}
 	if params.ErrorsOnly {
 		whereParts = append(whereParts, "exception_code != 0")
+	}
+	if params.LogComment != "" {
+		whereParts = append(whereParts, "log_comment ILIKE ?")
+		whereArgs = append(whereArgs, params.LogComment)
 	}
 
 	allowedSorts := map[string]bool{
@@ -408,6 +413,10 @@ func (c *Client) ListFingerprints(ctx context.Context, params QueryListParams) (
 	if params.User != "" {
 		whereParts = append(whereParts, "user = ?")
 		whereArgs = append(whereArgs, params.User)
+	}
+	if params.LogComment != "" {
+		whereParts = append(whereParts, "log_comment ILIKE ?")
+		whereArgs = append(whereArgs, params.LogComment)
 	}
 
 	sortBy := "last_seen"

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -172,6 +172,7 @@ export interface QueryListParams {
   min_memory?: number;
   min_read_bytes?: number;
   errors_only?: boolean;
+  log_comment?: string;
   search?: string;
   sort_by?: string;
   sort_dir?: string;

--- a/web/src/pages/QueryFingerprints.tsx
+++ b/web/src/pages/QueryFingerprints.tsx
@@ -60,6 +60,7 @@ export function QueryFingerprints({ connected }: { connected: boolean }) {
   const [showFilters, setShowFilters] = useState(false);
   const [search, setSearch] = useState("");
   const [user, setUser] = useState("");
+  const [logComment, setLogComment] = useState("");
   const [sortBy, setSortBy] = useState<SortField>("last_seen");
   const [sortDir, setSortDir] = useState<"DESC" | "ASC">("DESC");
   const [currentPage, setCurrentPage] = useState(1);
@@ -84,6 +85,7 @@ export function QueryFingerprints({ connected }: { connected: boolean }) {
       const result = await fetchFingerprints({
         search: debouncedSearch || undefined,
         user: user || undefined,
+        log_comment: logComment || undefined,
         sort_by: sortBy,
         sort_dir: sortDir,
         limit: pageSize,
@@ -104,7 +106,7 @@ export function QueryFingerprints({ connected }: { connected: boolean }) {
     } finally {
       if (!signal?.aborted) setLoading(false);
     }
-  }, [debouncedSearch, user, sortBy, sortDir, currentPage, showSystem, fromTime, toTime, wantsCount]);
+  }, [debouncedSearch, user, logComment, sortBy, sortDir, currentPage, showSystem, fromTime, toTime, wantsCount]);
 
   const cancel = useCallback(() => {
     setCanceled(true);
@@ -215,6 +217,16 @@ export function QueryFingerprints({ connected }: { connected: boolean }) {
                 onChange={(e) => { setUser(e.target.value); setCurrentPage(1); }}
                 placeholder="Username"
                 className="w-full"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs text-[var(--color-text-secondary)]">Log Comment</label>
+              <Input
+                value={logComment}
+                onChange={(e) => { setLogComment(e.target.value); setCurrentPage(1); }}
+                placeholder="e.g. %nightly%"
+                title="SQL LIKE pattern on log_comment. % and _ are wildcards."
+                className="w-full font-mono"
               />
             </div>
           </div>

--- a/web/src/pages/QueryList.tsx
+++ b/web/src/pages/QueryList.tsx
@@ -61,6 +61,7 @@ export function QueryList({ connected }: { connected: boolean }) {
     min_memory: Number(urlParam("min_memory")) || undefined,
     min_read_bytes: Number(urlParam("min_read_bytes")) || undefined,
     errors_only: urlParam("errors_only") === "true",
+    log_comment: urlParam("log_comment"),
   });
   const [search, setSearch] = useState(urlParam("q"));
   const [showFilters, setShowFilters] = useState(false);
@@ -82,6 +83,7 @@ export function QueryList({ connected }: { connected: boolean }) {
     if (params.min_memory) sp.set("min_memory", String(params.min_memory));
     if (params.min_read_bytes) sp.set("min_read_bytes", String(params.min_read_bytes));
     if (params.errors_only) sp.set("errors_only", "true");
+    if (params.log_comment) sp.set("log_comment", params.log_comment);
     if (!params.hide_system_queries) sp.set("hide_system", "false");
     setSearchParams(sp, { replace: true });
   }, [search, params, setSearchParams]);
@@ -207,7 +209,7 @@ export function QueryList({ connected }: { connected: boolean }) {
         </Button>
       </div>
 
-      {(params.user || params.database || params.table || params.errors_only) && (
+      {(params.user || params.database || params.table || params.errors_only || params.log_comment) && (
         <div className="mb-2 flex flex-wrap items-center gap-1.5">
           <span className="text-xs text-[var(--color-text-secondary)]">Filtered by:</span>
           {params.user && (
@@ -218,6 +220,9 @@ export function QueryList({ connected }: { connected: boolean }) {
           )}
           {params.table && (
             <Chip onClear={() => setParams((p) => ({ ...p, table: undefined, offset: 0 }))} label={`table: ${params.table}`} />
+          )}
+          {params.log_comment && (
+            <Chip onClear={() => setParams((p) => ({ ...p, log_comment: undefined, offset: 0 }))} label={`log_comment: ${params.log_comment}`} />
           )}
           {params.errors_only && (
             <Chip onClear={() => setParams((p) => ({ ...p, errors_only: false, offset: 0 }))} label="failed only" />
@@ -276,6 +281,16 @@ export function QueryList({ connected }: { connected: boolean }) {
                 onChange={(e) => setParams((p) => ({ ...p, user: e.target.value || undefined, offset: 0 }))}
                 placeholder="Username"
                 className="w-full"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs text-[var(--color-text-secondary)]">Log Comment</label>
+              <Input
+                value={params.log_comment || ""}
+                onChange={(e) => setParams((p) => ({ ...p, log_comment: e.target.value || undefined, offset: 0 }))}
+                placeholder="e.g. %nightly%"
+                title="SQL LIKE pattern on log_comment. % and _ are wildcards."
+                className="w-full font-mono"
               />
             </div>
             <div className="space-y-1">

--- a/web/src/pages/editor/ResultTable.tsx
+++ b/web/src/pages/editor/ResultTable.tsx
@@ -35,7 +35,7 @@ function CellValue({ val }: { val: unknown }) {
     <span className="group/cell relative inline-flex max-w-full items-center">
       <span
         onDoubleClick={() => setExpanded((e) => !e)}
-        className={`${expanded ? "whitespace-pre-wrap break-all" : "truncate"} ${isNull ? "italic text-[var(--color-text-secondary)]" : isObj ? "text-[var(--color-accent)]" : ""}`}
+        className={`${expanded ? "block max-h-[300px] overflow-auto whitespace-pre" : "truncate"} ${isNull ? "italic text-[var(--color-text-secondary)]" : isObj ? "text-[var(--color-accent)]" : ""}`}
         title={expanded ? undefined : (isObj ? JSON.stringify(val, null, 2) : display)}
       >
         {display}


### PR DESCRIPTION
## Summary

Two small UX changes.

### 1. `log_comment` filter on Queries + Fingerprints
- New filter wired through the Go `QueryListParams` struct, both `ListQueries` and `ListFingerprints` (and their HTTP handlers), the TS `QueryListParams`, and both pages' filter cards / chips / URL sync.
- Uses SQL `ILIKE` with the user's value verbatim, so `%` and `_` are wildcards (e.g. `%nightly%`). Plain `nightly` matches only the literal value — placeholder text `e.g. %nightly%` makes the semantics obvious.

### 2. SQL editor — expanded result cells scroll instead of stretching
- `CellValue` in `ResultTable.tsx` now renders expanded content as a `max-h-[300px] overflow-auto whitespace-pre` block instead of `whitespace-pre-wrap break-all` inside the 384px-capped `<td>`.
- Long SQL no longer wraps into a giant tall cell; long lines scroll horizontally, long content scrolls vertically. The `max-w-sm` cap on the cell is preserved so one wide cell can't shove the other columns off-screen.

## Verification
- \`go build ./...\` + \`go test -race -count=1 ./internal/clickhouse/... ./internal/api/...\` — pass
- \`npm run build\` (tsc + vite) — clean
- \`gofmt -l internal/\` — no diffs

## Manual checks
- Queries page: type `%foo%` in the new Log Comment filter → list narrows, chip appears, URL updates, clear-via-chip works.
- Fingerprints page: same.
- SQL editor: double-click a long SQL cell → expands to a scrollable block (~300px tall) instead of stretching the row.