### PR TITLE
fix(access): apply search filter on roles tab

### DIFF
--- a/web/src/pages/UsersAccess.tsx
+++ b/web/src/pages/UsersAccess.tsx
@@ -177,7 +177,8 @@ export function UsersAccess({ connected }: { connected: boolean }) {
             const usersF = q ? data.users.filter((u) => u.name.toLowerCase().includes(q) || (u.auth_type ?? []).some((a) => a.toLowerCase().includes(q)) || (u.default_roles ?? []).some((r) => r.toLowerCase().includes(q))) : data.users;
             const grantsF = q ? data.grants.filter((g) => (g.user_name || g.role_name || "").toLowerCase().includes(q) || g.access_type.toLowerCase().includes(q) || `${g.database}.${g.table}`.toLowerCase().includes(q)) : data.grants;
             const quotaF = q ? data.quota_usage.filter((k) => (k.quota_name || "").toLowerCase().includes(q) || (k.quota_key || "").toLowerCase().includes(q)) : data.quota_usage;
-            const paged = tab === "grants" ? grantsF : tab === "users" ? usersF : quotaF;
+            const rolesF = q ? data.roles.filter((r) => r.name.toLowerCase().includes(q)) : data.roles;
+            const paged = tab === "grants" ? grantsF : tab === "users" ? usersF : tab === "roles" ? rolesF : quotaF;
             const totalPages = Math.max(1, Math.ceil(paged.length / pageSize));
             const safePage = Math.min(page, totalPages);
             const start = (safePage - 1) * pageSize;
@@ -188,12 +189,12 @@ export function UsersAccess({ connected }: { connected: boolean }) {
                   <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--color-text-secondary)]" />
                   <Input value={query} onChange={(e) => { setQuery(e.target.value); setPage(1); }} placeholder={`Search ${tab}…`} className="h-7 pl-8 text-xs" />
                 </div>
-                {tab !== "grants" && paged.length > pageSize && (
+                {tab !== "grants" && tab !== "roles" && paged.length > pageSize && (
                   <Pagination page={safePage} pageSize={pageSize} total={paged.length} onPage={setPage} onPageSize={(s) => { setPageSize(s); setPage(1); }} />
                 )}
               </div>
               {tab === "users" && <UsersRolesTab users={usersF.slice(start, start + pageSize)} canManage={canManage} onDrop={setDropTarget} onRoleClick={showRole} />}
-              {tab === "roles" && <RolesTab roles={data.roles} grants={data.grants} roleGrants={data.role_grants} focusRole={roleFilter} canManage={canManage} onDrop={setDropTarget} />}
+              {tab === "roles" && <RolesTab roles={rolesF} grants={data.grants} roleGrants={data.role_grants} focusRole={roleFilter} canManage={canManage} onDrop={setDropTarget} />}
               {tab === "grants" && <GrantsTab grants={grantsF} canManage={canManage} onRevoke={setRevokeTarget} onRoleClick={showRole} />}
               {tab === "quota" && <QuotaTab rows={quotaF.slice(start, start + pageSize)} definitions={data.quotas} />}
             </>


### PR DESCRIPTION
## Problem

The search box on the **Roles** tab of `/access` did nothing — typing into it never filtered the list.

## Root cause

In `web/src/pages/UsersAccess.tsx`, every other tab filters its rows by the query before rendering:

- users → `usersF`
- grants → `grantsF`
- quota   → `quotaF`

…but the roles tab passed `data.roles` straight through unfiltered, and no `rolesF` existed.

Two related bugs fell out of the same gap:

1. `paged` fell through to `quotaF` on the roles tab, so the pagination widget's totals were computed from quota rows.
2. `RolesTab` doesn't slice by page, so if that pagination widget did render it would have been non-functional.

## Fix

- Add `rolesF` (filter by role name, case-insensitive — same pattern as the other tabs).
- Route roles through `rolesF` in `paged`.
- Hide the pagination control on the roles tab, matching the grants tab (both are collapsible, non-paginated).
- Pass `rolesF` to `<RolesTab />`.

## Verification

- `npx tsc -b` — clean
- `npm test` — 108/108 pass
- Manual: typing in the search box on the Roles tab now filters the list live.

Skipped: paginating roles (would only matter past ~50 roles). Add when the list grows.
