### PR TITLE
feat(access): match role members in roles tab search

### DIFF
--- a/web/src/pages/UsersAccess.tsx
+++ b/web/src/pages/UsersAccess.tsx
@@ -177,7 +177,7 @@ export function UsersAccess({ connected }: { connected: boolean }) {
             const usersF = q ? data.users.filter((u) => u.name.toLowerCase().includes(q) || (u.auth_type ?? []).some((a) => a.toLowerCase().includes(q)) || (u.default_roles ?? []).some((r) => r.toLowerCase().includes(q))) : data.users;
             const grantsF = q ? data.grants.filter((g) => (g.user_name || g.role_name || "").toLowerCase().includes(q) || g.access_type.toLowerCase().includes(q) || `${g.database}.${g.table}`.toLowerCase().includes(q)) : data.grants;
             const quotaF = q ? data.quota_usage.filter((k) => (k.quota_name || "").toLowerCase().includes(q) || (k.quota_key || "").toLowerCase().includes(q)) : data.quota_usage;
-            const rolesF = q ? data.roles.filter((r) => r.name.toLowerCase().includes(q)) : data.roles;
+            const rolesF = q ? data.roles.filter((r) => r.name.toLowerCase().includes(q) || data.role_grants.some((rg) => rg.granted_role_name === r.name && rg.user_name.toLowerCase().includes(q))) : data.roles;
             const paged = tab === "grants" ? grantsF : tab === "users" ? usersF : tab === "roles" ? rolesF : quotaF;
             const totalPages = Math.max(1, Math.ceil(paged.length / pageSize));
             const safePage = Math.min(page, totalPages);


### PR DESCRIPTION
## What

Typing a member's username in the **Roles** tab search box now also surfaces any role that user belongs to (alongside the existing role-name match).

## How

Extended `rolesF` to also match when any `role_grants` row for that role has a `user_name` matching the query. One-line change, consistent with the existing nested-`.some()` style used in `usersF`.

```diff
-const rolesF = q ? data.roles.filter((r) => r.name.toLowerCase().includes(q)) : data.roles;
+const rolesF = q ? data.roles.filter((r) => r.name.toLowerCase().includes(q) || data.role_grants.some((rg) => rg.granted_role_name === r.name && rg.user_name.toLowerCase().includes(q))) : data.roles;
```

## Notes

- O(roles × role_grants) per keystroke — fine at typical ClickHouse scale (hundreds of each). If a deployment ever has tens of thousands of members, precompute a role→members map.
- Case-insensitive, same as the other tabs.

## Verification

- `npx tsc -b` — clean
- `npm test` — 108/108 pass
