### PR TITLE
fix(access): use string literal for SHOW GRANTS FOR grantee

### DIFF
--- a/internal/clickhouse/access.go
+++ b/internal/clickhouse/access.go
@@ -294,10 +294,13 @@ func (c *Client) DropRole(ctx context.Context, name string) error {
 
 // ShowGrantsFor runs `SHOW GRANTS FOR {USER|ROLE} <name>` and returns the
 // grant statements joined with newlines (ClickHouse returns one row per
-// grant). kind must be "USER" or "ROLE". Privileges are re-checked by the
-// server; an unauthorized caller gets a CH_EXCEPTION that surfaces as-is.
+// grant). kind must be "USER" or "ROLE". The name is passed as a SQL string
+// literal, not a backtick-quoted identifier — SHOW GRANTS parses the grantee
+// as a bare token or string, and backticks trigger SYNTAX_ERROR. Privileges
+// are re-checked by the server; an unauthorized caller gets a CH_EXCEPTION
+// that surfaces as-is.
 func (c *Client) ShowGrantsFor(ctx context.Context, kind, name string) (string, error) {
-	rows, err := c.conn.Query(ctx, fmt.Sprintf("SHOW GRANTS FOR %s %s", kind, quoteIdent(name)))
+	rows, err := c.conn.Query(ctx, fmt.Sprintf("SHOW GRANTS FOR %s %s", kind, quoteStr(name)))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Bug

After #22 merged, clicking the `FileCode` button on a user/role returns HTTP 400:

```
Code: 62. DB::Exception: Syntax error: failed at position 22 (`username01`): `username01`.
Expected one of: token, At, Comma, EXCEPT, WITH IMPLICIT, FINAL, … (SYNTAX_ERROR)
```

## Root cause

`ShowGrantsFor` reused `quoteIdent` (backtick-quoting) for the grantee name. `SHOW GRANTS FOR` doesn't accept backtick-quoted identifiers — the parser expects a bare token or a single-quoted string literal. The previous query was:

```sql
SHOW GRANTS FOR USER `username01`   -- SYNTAX_ERROR
```

## Fix

Use the existing `quoteStr` helper (same `clickhouse` package, already used by `table_optimizer.go` for the same purpose) to emit a SQL string literal:

```sql
SHOW GRANTS FOR USER 'username01'    -- OK
```

One-line behaviour change; comment on `ShowGrantsFor` updated to call out the trap so it doesn't get re-introduced.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- Manual: clicking 'Show grants' on a user/role now returns the expected `GRANT …` rows.
