### PR TITLE
feat(access): SHOW GRANTS clarity + execute path fix

### DIFF
--- a/internal/clickhouse/execute.go
+++ b/internal/clickhouse/execute.go
@@ -105,12 +105,18 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string, limit, offset i
 	defer cancel()
 
 	selectLike := isSelectLike(query)
+	// SHOW GRANTS can't be used as a subquery source — ClickHouse's FROM-clause
+	// parser rejects it with SYNTAX_ERROR. Skip the wrapping (and the count
+	// query below) for SHOW GRANTS and execute it verbatim. Result sets are
+	// small enough that pagination isn't useful anyway.
+	upper := strings.ToUpper(strings.TrimSpace(query))
+	isShowGrants := strings.HasPrefix(upper, "SHOW GRANTS")
 
 	// For SELECT-like queries, wrap in a subquery to apply a deterministic
 	// LIMIT/OFFSET window. For everything else (DDL/DML), execute verbatim
 	// with a max_result_rows ceiling as defense-in-depth.
 	var executedQuery string
-	if selectLike && !hasFormatClause(query) {
+	if selectLike && !hasFormatClause(query) && !isShowGrants {
 		executedQuery = fmt.Sprintf("SELECT * FROM (%s) LIMIT %d OFFSET %d", query, limit, offset)
 	} else {
 		executedQuery = query
@@ -254,7 +260,7 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string, limit, offset i
 	// first page (offset 0) to amortize the cost. Cached client-side thereafter.
 	// Returns -1 (unknown) if the count query fails or the query isn't SELECT-like.
 	totalRows := int64(-1)
-	if selectLike && offset == 0 {
+	if selectLike && !isShowGrants && offset == 0 {
 		countQuery := fmt.Sprintf("SELECT count() FROM (%s)", query)
 		var n uint64
 		if err := c.conn.QueryRow(ctx, countQuery).Scan(&n); err == nil {

--- a/web/src/pages/UsersAccess.tsx
+++ b/web/src/pages/UsersAccess.tsx
@@ -235,7 +235,12 @@ export function UsersAccess({ connected }: { connected: boolean }) {
           <SqlStatementDialog
             open={!!grantsTarget}
             onOpenChange={(v) => !v && setGrantsTarget(null)}
-            title={grantsTarget ? <span className="font-mono text-sm">{grantsTarget.name}</span> : ""}
+            title={grantsTarget ? (
+              <span className="font-mono text-sm">
+                <span className="text-[var(--color-text-secondary)]">SHOW GRANTS FOR</span>{" "}
+                {grantsTarget.name}
+              </span>
+            ) : ""}
             load={loadGrants}
             loadingLabel="Loading grants…"
             copyLabel="Grants copied!"


### PR DESCRIPTION
## What

Two related improvements for the `SHOW GRANTS` experience:

### 1. Modal title shows the statement (frontend)

The grants dialog on `/access` now shows the full statement being executed:

```
SHOW GRANTS FOR airbyte
```

instead of just `airbyte`. Makes it obvious what the dialog is rendering. Keyword in secondary color, grantee in primary — same visual pattern used for grant rows elsewhere.

### 2. SQL editor no longer wraps SHOW GRANTS in a subquery (backend)

Running `SHOW GRANTS FOR 'analyst2'` in the SQL editor previously failed with:

```
Code: 62. DB::Exception: Syntax error: failed at position 21 (grants):
grants for 'analyst2') LIMIT 100 OFFSET 0. Expected one of: token sequence,
Dot, token, … table, table function, subquery … (SYNTAX_ERROR)
```

**Root cause:** `ExecuteQuery` wraps SELECT-like queries as `SELECT * FROM (...) LIMIT n OFFSET m` for pagination, and runs `SELECT count() FROM (...)` for totals. ClickHouse's FROM-clause parser doesn't accept `SHOW GRANTS` as a subquery source — both wrapped forms fail.

**Fix:** Skip both the wrapping and the count query when the query starts with `SHOW GRANTS`; execute verbatim instead. Result sets are small (a handful of GRANT statements per grantee) so losing OFFSET pagination is immaterial. Other SHOW statements are unaffected (only `SHOW GRANTS` is excluded).

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `npx tsc -b` — clean
- Manual: `SHOW GRANTS FOR 'name'` now runs successfully from the SQL editor.
