### PR TITLE
fix(access): drop USER/ROLE keyword from SHOW GRANTS FOR button

### DIFF
--- a/internal/api/query_handlers.go
+++ b/internal/api/query_handlers.go
@@ -815,7 +815,7 @@ func (a *API) GetRoleGrants(w http.ResponseWriter, r *http.Request) {
 		CHUnreachable(w, false, err)
 		return
 	}
-	stmt, err := ch.ShowGrantsFor(r.Context(), "ROLE", name)
+	stmt, err := ch.ShowGrantsFor(r.Context(), name)
 	if err != nil {
 		respondErr(w, err, false)
 		return
@@ -830,7 +830,7 @@ func (a *API) GetUserGrants(w http.ResponseWriter, r *http.Request) {
 		CHUnreachable(w, false, err)
 		return
 	}
-	stmt, err := ch.ShowGrantsFor(r.Context(), "USER", name)
+	stmt, err := ch.ShowGrantsFor(r.Context(), name)
 	if err != nil {
 		respondErr(w, err, false)
 		return

--- a/internal/clickhouse/access.go
+++ b/internal/clickhouse/access.go
@@ -292,15 +292,20 @@ func (c *Client) DropRole(ctx context.Context, name string) error {
 	return c.conn.Exec(ctx, fmt.Sprintf("DROP ROLE IF EXISTS %s", quoteIdent(name)))
 }
 
-// ShowGrantsFor runs `SHOW GRANTS FOR {USER|ROLE} <name>` and returns the
-// grant statements joined with newlines (ClickHouse returns one row per
-// grant). kind must be "USER" or "ROLE". The name is passed as a SQL string
-// literal, not a backtick-quoted identifier — SHOW GRANTS parses the grantee
-// as a bare token or string, and backticks trigger SYNTAX_ERROR. Privileges
-// are re-checked by the server; an unauthorized caller gets a CH_EXCEPTION
-// that surfaces as-is.
-func (c *Client) ShowGrantsFor(ctx context.Context, kind, name string) (string, error) {
-	rows, err := c.conn.Query(ctx, fmt.Sprintf("SHOW GRANTS FOR %s %s", kind, quoteStr(name)))
+// ShowGrantsFor runs `SHOW GRANTS FOR <name> FINAL` and returns the grant
+// statements joined with newlines (ClickHouse returns one row per grant).
+// FINAL merges in grants inherited via granted roles.
+//
+// ClickHouse grammar: `SHOW GRANTS [FOR user1 [, user2 ...]] [WITH IMPLICIT] [FINAL]`.
+// Two traps: there is no USER/ROLE keyword (it would be parsed as the
+// grantee name), and the grantee must be a bare identifier — backtick- and
+// string-quoting both fail in this position. Names come from system.users /
+// system.roles (trusted); any name that isn't a valid identifier fails with
+// a graceful SYNTAX_ERROR rather than enabling injection.
+// Privileges are re-checked by the server; an unauthorized caller gets a
+// CH_EXCEPTION that surfaces as-is.
+func (c *Client) ShowGrantsFor(ctx context.Context, name string) (string, error) {
+	rows, err := c.conn.Query(ctx, fmt.Sprintf("SHOW GRANTS FOR %s FINAL", name))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Bug

After merging #24, the **button** on `/access` still fails:

```
Syntax error: failed at position 22 ('analyst1'). Expected one of: token,
At, Comma, EXCEPT, WITH IMPLICIT, FINAL, … (SYNTAX_ERROR)
```

## Root cause

`fix/show-grants-syntax` was prepared earlier (the proper button fix that drops the `USER` keyword) but never opened as a PR — only the intermediate `fix/show-grants-quoting` (#23, which still had the keyword) and `feat/show-grants-modal-label` (#24, frontend-only) got merged. So main still issues:

```sql
SHOW GRANTS FOR USER 'analyst1'   -- SYNTAX_ERROR
```

ClickHouse's grammar is `SHOW GRANTS [FOR user1 [, user2 ...]] [WITH IMPLICIT] [FINAL]` — **no `USER`/`ROLE` keyword**. The parser treats `USER` as the grantee name, then chokes on the actual name.

## Fix

Per the [grammar](https://clickhouse.com/docs/en/sql-reference/statements/show/#show-grants), drop the keyword and use a bare identifier. Bonus: `FINAL` is valid syntax and merges in grants inherited via granted roles (which is what was originally requested). Issued query becomes:

```sql
SHOW GRANTS FOR analyst1 FINAL
```

The now-unused `kind` parameter is dropped from `ShowGrantsFor` and its two callers.

Names come from `system.users` / `system.roles` (trusted); any non-identifier name fails with a graceful SYNTAX_ERROR rather than enabling injection.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
