### PR TITLE
fix(explain): skip EXPLAIN on non-SELECT queries and lazy-load it

### DIFF
--- a/internal/clickhouse/execute.go
+++ b/internal/clickhouse/execute.go
@@ -71,13 +71,27 @@ func hasFormatClause(query string) bool {
 
 func isSelectLike(query string) bool {
 	trimmed := strings.TrimSpace(query)
-	// strip a leading SQL line comment
-	for strings.HasPrefix(trimmed, "--") {
-		nl := strings.IndexByte(trimmed, '\n')
-		if nl < 0 {
-			return false
+	// strip leading SQL comments (line `-- ...` and block `/* ... */`) so a
+	// query like `/* ddl_entry=... */ DROP TABLE ...` is classified correctly.
+	for {
+		trimmed = strings.TrimSpace(trimmed)
+		switch {
+		case strings.HasPrefix(trimmed, "--"):
+			nl := strings.IndexByte(trimmed, '\n')
+			if nl < 0 {
+				return false
+			}
+			trimmed = trimmed[nl+1:]
+			continue
+		case strings.HasPrefix(trimmed, "/*"):
+			end := strings.Index(trimmed, "*/")
+			if end < 0 {
+				return false
+			}
+			trimmed = trimmed[end+2:]
+			continue
 		}
-		trimmed = strings.TrimSpace(trimmed[nl+1:])
+		break
 	}
 	upper := strings.ToUpper(trimmed)
 	switch {

--- a/internal/clickhouse/execute_test.go
+++ b/internal/clickhouse/execute_test.go
@@ -90,3 +90,38 @@ func TestIsProbablyJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestIsSelectLike(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"plain select", "SELECT 1", true},
+		{"select lowercase", "select * from t", true},
+		{"with clause", "WITH x AS (SELECT 1) SELECT * FROM x", true},
+		{"show", "SHOW TABLES", true},
+		{"describe", "DESCRIBE TABLE t", true},
+		{"leading line comment", "-- hello\nSELECT 1", true},
+		{"leading block comment", "/* tag */ SELECT 1", true},
+		{"ddl_entry block comment on select", "/* ddl_entry=q-1 */ SELECT 1", true},
+		{"block then line comment", "/* a */\n-- b\nSELECT 1", true},
+		{"unterminated block comment", "/* never ends SELECT 1", false},
+		{"unterminated line comment", "-- never ends", false},
+		{"drop table", "DROP TABLE t", false},
+		{"ddl_entry block comment on drop", "/* ddl_entry=query-0000389051 */ DROP TABLE IF EXISTS analytics.events SYNC", false},
+		{"create", "CREATE TABLE t (x Int32)", false},
+		{"insert select", "INSERT INTO t SELECT * FROM s", false},
+		{"alter", "ALTER TABLE t ADD COLUMN x Int32", false},
+		{"empty", "", false},
+		{"whitespace only", "   \n\t  ", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSelectLike(tt.query); got != tt.want {
+				t.Errorf("isSelectLike(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/clickhouse/explain.go
+++ b/internal/clickhouse/explain.go
@@ -26,6 +26,17 @@ type ExplainEstimate struct {
 }
 
 func (c *Client) GetExplain(ctx context.Context, query string) (*ExplainResult, error) {
+	// EXPLAIN PLAN/PIPELINE/ESTIMATE only parse SELECT-like statements.
+	// Running them on DDL/DML produces five SYNTAX_ERRORs in the ClickHouse
+	// log per view, so short-circuit before touching the connection.
+	if !isSelectLike(query) {
+		return &ExplainResult{
+			Errors: map[string]string{
+				"skipped": "EXPLAIN only applies to SELECT-like queries; this query is not explainable",
+			},
+		}, nil
+	}
+
 	result := &ExplainResult{Errors: map[string]string{}}
 
 	plan, err := c.runExplain(ctx, "EXPLAIN PLAN", query)

--- a/internal/clickhouse/explain_test.go
+++ b/internal/clickhouse/explain_test.go
@@ -1,0 +1,63 @@
+package clickhouse
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestGetExplain_SkipsNonSelect verifies that EXPLAIN is not even attempted
+// for non-SELECT queries. Previously each view of a DDL/DML query in the UI
+// fired five EXPLAIN variants at ClickHouse, every one failing with
+// SYNTAX_ERROR and polluting the server's error log. The guard must
+// short-circuit before any connection use.
+func TestGetExplain_SkipsNonSelect(t *testing.T) {
+	// Zero-value Client: conn is nil. If the guard fails and the function
+	// tries to use it, the test crashes — which is the failure signal we want.
+	c := &Client{}
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"drop table", "DROP TABLE analytics.events"},
+		{"ddl_entry commented drop", "/* ddl_entry=query-0000389051 */ DROP TABLE IF EXISTS analytics.events SYNC"},
+		{"create", "CREATE TABLE t (x Int32)"},
+		{"insert", "INSERT INTO t VALUES (1)"},
+		{"alter", "ALTER TABLE t ADD COLUMN x Int32"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := c.GetExplain(context.Background(), tt.query)
+			if err != nil {
+				t.Fatalf("GetExplain returned err: %v", err)
+			}
+			if res == nil {
+				t.Fatal("GetExplain returned nil result")
+			}
+			if res.Plan != "" || res.Pipeline != "" || res.PipelineGraph != "" || res.Syntax != "" || res.Estimate != nil {
+				t.Errorf("expected empty result, got %+v", res)
+			}
+			msg := res.Errors["skipped"]
+			if msg == "" {
+				t.Fatalf("expected errors[skipped] to be set, got %v", res.Errors)
+			}
+			if !strings.Contains(msg, "SELECT") {
+				t.Errorf("skipped message should mention SELECT, got %q", msg)
+			}
+		})
+	}
+}
+
+// TestGetExplain_AttemptsSelect confirms the happy path actually reaches the
+// connection (i.e. the guard doesn't over-eagerly skip SELECTs). A nil conn
+// will panic if we get there — that's the success signal.
+func TestGetExplain_AttemptsSelect(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected GetExplain to use the connection for a SELECT, but it returned without panicking (guard is too aggressive)")
+		}
+	}()
+	c := &Client{}
+	_, _ = c.GetExplain(context.Background(), "SELECT 1")
+}

--- a/web/src/pages/QueryDetail.tsx
+++ b/web/src/pages/QueryDetail.tsx
@@ -74,14 +74,12 @@ export function QueryDetail({ connected }: { connected: boolean }) {
       fetchQueryMetrics(queryId, controller.signal).catch(() => []),
       fetchQueryThreads(queryId, controller.signal).catch(() => []),
       fetchQueryViews(queryId, controller.signal).catch(() => []),
-      fetchExplain(queryId, controller.signal).catch(() => null),
-    ]).then(([q, m, t, v, e]) => {
+    ]).then(([q, m, t, v]) => {
       if (aborted) return;
       setQuery(q);
       setMetrics(m || []);
       setThreads(t || []);
       setViews(v || []);
-      if (e) setExplain(e);
     }).catch((e) => {
       if (aborted) return;
       setError(e instanceof ApiError ? e : ApiError.wrap(e));
@@ -143,6 +141,13 @@ export function QueryDetail({ connected }: { connected: boolean }) {
   useEffect(() => {
     if (tab === "flamegraph" && queryId && flameData.length === 0 && !flameLoading) {
       loadFlameGraph();
+    }
+    // Lazy-load EXPLAIN only when the user actually opens a tab that needs it
+    // (Explain, or Threads which renders the pipeline). Auto-loading on every
+    // QueryDetail mount fired 5 EXPLAIN queries per page view, polluting
+    // system.processes and the error log when the underlying query was DDL.
+    if ((tab === "explain" || tab === "threads") && queryId && !explain) {
+      loadExplain();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queryId, tab]);
@@ -271,7 +276,6 @@ export function QueryDetail({ connected }: { connected: boolean }) {
                 else prev.set("tab", t.key);
                 return prev;
               }, { replace: true });
-              if (t.key === "explain") loadExplain();
               if (t.key === "flamegraph") loadFlameGraph();
             }}
             className={`px-4 py-2 text-sm capitalize transition-colors ${

--- a/web/src/pages/query-detail/ExplainTab.tsx
+++ b/web/src/pages/query-detail/ExplainTab.tsx
@@ -1,4 +1,4 @@
-import { Play, AlertCircle } from "lucide-react";
+import { Play, AlertCircle, Ban } from "lucide-react";
 import CodeMirror from "@uiw/react-codemirror";
 import { sql } from "@codemirror/lang-sql";
 import { oneDark } from "@codemirror/theme-one-dark";
@@ -52,10 +52,19 @@ export function ExplainTab({ explain }: ExplainTabProps) {
 
   const hasContent = !!(explain && (explain.plan || explain.pipeline || explain.pipeline_graph || explain.syntax || explain.estimate));
   const errorEntries = explain?.errors ? Object.entries(explain.errors) : [];
+  const skipped = !!explain?.errors?.skipped;
 
   return (
     <div className="space-y-4">
-      {hasContent ? (
+      {skipped ? (
+        <div className="flex flex-col items-center gap-4 rounded-lg border border-[var(--color-border)] bg-[var(--surface-card)] px-6 py-10 text-center">
+          <Ban className="h-8 w-8 text-[var(--color-text-secondary)]" />
+          <div className="text-sm font-medium text-[var(--color-text-primary)]">EXPLAIN not available for this query</div>
+          <p className="max-w-md text-xs text-[var(--color-text-secondary)]">
+            {explain?.errors?.skipped}
+          </p>
+        </div>
+      ) : hasContent ? (
         <>
           {explain && explain.estimate && <EstimateCard estimate={explain.estimate} />}
           {explain && explain.plan && (


### PR DESCRIPTION
## Root cause

Two related bugs around EXPLAIN:

1. **EXPLAIN on DDL/DML floods the ClickHouse error log.** `GetExplain` blindly prepended 5 EXPLAIN variants (`EXPLAIN PLAN`, `EXPLAIN PIPELINE`, `EXPLAIN PIPELINE graph=1`, `EXPLAIN SYNTAX`, `EXPLAIN ESTIMATE`) to whatever query text it received. For non-SELECT queries every variant fails with `SYNTAX_ERROR` and lands in the server log — e.g. `EXPLAIN PIPELINE graph=1 /* ddl_entry=query-0000389051 */ DROP TABLE IF EXISTS analytics.events SYNC`.

2. **EXPLAIN fired on every QueryDetail page load.** The mount-time `useEffect` included `fetchExplain` in its parallel `Promise.all`, so opening any query (including clicking a row on the Running Queries page) fired 5 EXPLAINs against ClickHouse even if the user never opened the Explain tab. Those queries were visible in `system.processes` and added to log noise when they failed. The `ExplainTab` even had an unused "Click explain tab" placeholder state.

## Fix

**Backend** (`internal/clickhouse/explain.go`, `execute.go`)
- `GetExplain` short-circuits with `Errors['skipped']` when the query isn't SELECT-like — no ClickHouse round-trip, no log pollution.
- `isSelectLike` now strips leading `/* ... */` block comments in addition to `--` line comments, so tagged DDL like `/* ddl_entry=... */ DROP TABLE ...` is classified correctly.

**Frontend** (`web/src/pages/QueryDetail.tsx`, `query-detail/ExplainTab.tsx`)
- Removed `fetchExplain` from the mount-time `Promise.all`.
- Added a `useEffect` that lazy-loads EXPLAIN when the user opens the Explain or Threads tab (Threads consumes `explain.pipeline`). Deep links (`?tab=explain`, `?tab=threads`) still work.
- `ExplainTab` renders a dedicated "EXPLAIN not available for this query" state when the backend skips.

## Tests
- `TestIsSelectLike` — covers block comments, the reported `/* ddl_entry=... */ DROP TABLE` case, and the existing happy paths.
- `TestGetExplain_SkipsNonSelect` — verifies the guard returns `errors['skipped']` for DDL/DML without touching the connection.
- `TestGetExplain_AttemptsSelect` — confirms SELECT still reaches the connection (guard isn't over-eager).

## Verification
```
make test-unit    # pass (incl. new tests)
make lint         # 0 issues
cd web && npm run build  # tsc + vite OK
cd web && npm test       # 108 tests pass
```

## Out of scope
- `INSERT ... SELECT` is still classified as non-SELECT (matches existing behavior). Can revisit if anyone wants EXPLAIN on insert-select.
- The `EXISTS TABLE SELECT ...` error from the report is not generated by this repo (no such literal in source); it's just another query in `query_log` that the same guard now prevents ClickLens from trying to EXPLAIN.