### PR TITLE
fix(queries): use log_comment as sole signal for internal queries

### DIFF
--- a/internal/clickhouse/processes.go
+++ b/internal/clickhouse/processes.go
@@ -24,8 +24,12 @@ type ProcessEntry struct {
 	NormalizedQueryHash string    `json:"normalized_query_hash"`
 	QueryKind           string    `json:"query_kind"`
 	Database            string    `json:"current_database"`
-	IsInitialQuery      uint8     `json:"is_initial_query"`
-	InitialQueryID      string    `json:"initial_query_id"`
+	// LogComment is the value of the log_comment setting for this query.
+	// ClickLens stamps its own queries with managedLogComment; the frontend
+	// uses this (and only this) to identify internal queries.
+	LogComment     string `json:"log_comment"`
+	IsInitialQuery uint8  `json:"is_initial_query"`
+	InitialQueryID string `json:"initial_query_id"`
 }
 
 // processColumns is the shared column list for system.processes, used by both
@@ -41,6 +45,7 @@ const processColumns = `query_id, query, user,
 	toString(normalized_query_hash) AS normalized_query_hash,
 	query_kind,
 	current_database,
+	log_comment,
 	is_initial_query, initial_query_id`
 
 func (p *ProcessEntry) scanTargets() []any {
@@ -52,6 +57,7 @@ func (p *ProcessEntry) scanTargets() []any {
 		&p.ThreadCount,
 		&p.NormalizedQueryHash, &p.QueryKind,
 		&p.Database,
+		&p.LogComment,
 		&p.IsInitialQuery, &p.InitialQueryID,
 	}
 }

--- a/internal/clickhouse/processes_test.go
+++ b/internal/clickhouse/processes_test.go
@@ -1,0 +1,41 @@
+package clickhouse
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProcessColumns_HasLogComment is a belt-and-suspenders check that
+// system.processes SELECTs surface log_comment so the frontend can identify
+// ClickLens's own queries (the sole signal for "internal").
+func TestProcessColumns_HasLogComment(t *testing.T) {
+	if !strings.Contains(processColumns, "log_comment") {
+		t.Errorf("processColumns = %q, expected to include log_comment", processColumns)
+	}
+}
+
+// TestProcessEntry_ScanTargets_LogComment makes sure the new LogComment field
+// is wired into scanTargets — otherwise the column would come back from
+// system.processes but never populate the struct, and the frontend filter
+// would never see "clicklens".
+func TestProcessEntry_ScanTargets_LogComment(t *testing.T) {
+	p := &ProcessEntry{}
+	targets := p.scanTargets()
+
+	// scanTargets returns a pointer per selected column. Mutate the field
+	// through the slice and confirm LogComment reflects it — that only
+	// works if the right pointer is in the slice.
+	logCommentValue := "clicklens"
+	for i, t := range targets {
+		if strPtr, ok := t.(*string); ok {
+			*strPtr = logCommentValue
+			if p.LogComment == logCommentValue {
+				return
+			}
+			// reset in case we picked the wrong *string on the way
+			*strPtr = ""
+		}
+		_ = i
+	}
+	t.Errorf("scanTargets() = %d entries, none pointed at &p.LogComment", len(targets))
+}

--- a/internal/clickhouse/query_log.go
+++ b/internal/clickhouse/query_log.go
@@ -71,17 +71,16 @@ var defaultListParams = QueryListParams{
 	SortDir: "DESC",
 }
 
-// hideSystemQueriesClause returns the SQL fragment used to suppress non-user
-// queries when "Hide system queries" is enabled. It does two things:
-//   - excludes DDL/session-control noise by query_kind (CREATE, DROP, ALTER,
-//     EXPLAIN, SET, USE, KILL, OPTIMIZE, etc.), and
-//   - excludes queries ClickLens issued itself, tagged via the log_comment
-//     setting.
+// hideSystemQueriesClause returns the SQL fragment used to suppress
+// ClickLens-issued queries when "Hide internal queries" is enabled.
+// "Internal" means only queries ClickLens itself issued, tagged via the
+// log_comment setting. We deliberately do NOT exclude by query_kind — that
+// hid user-issued DDL (e.g. dbt CREATE/DROP/ALTER) which is real workload.
 //
 // Notably it does NOT exclude queries merely for touching the system database,
 // so a user's own SELECT ... FROM system.* queries remain visible.
 func hideSystemQueriesClause() string {
-	return "lower(query_kind) NOT IN ('explain', 'system', 'show', 'create', 'drop', 'alter', 'set', 'use', 'kill', 'optimize', 'truncate', 'rename', 'check', 'detach', 'attach', 'none') AND log_comment != '" + managedLogComment + "'"
+	return "log_comment != '" + managedLogComment + "'"
 }
 
 func (c *Client) ListQueries(ctx context.Context, params QueryListParams) ([]QueryLogEntry, uint64, error) {

--- a/internal/clickhouse/query_log_test.go
+++ b/internal/clickhouse/query_log_test.go
@@ -34,13 +34,16 @@ func TestQueryListParams_Defaults(t *testing.T) {
 func TestHideSystemQueriesClause(t *testing.T) {
 	clause := hideSystemQueriesClause()
 
-	for _, want := range []string{
-		"lower(query_kind) NOT IN",
-		"log_comment != 'clicklens'",
-	} {
-		if !strings.Contains(clause, want) {
-			t.Errorf("hideSystemQueriesClause() = %q, expected to contain %q", clause, want)
-		}
+	if !strings.Contains(clause, "log_comment != 'clicklens'") {
+		t.Errorf("hideSystemQueriesClause() = %q, expected to contain %q", clause, "log_comment != 'clicklens'")
+	}
+
+	// "Internal" means only ClickLens-issued queries (log_comment tag).
+	// Earlier versions also excluded by query_kind (CREATE/DROP/ALTER/...),
+	// which hid real user workload like dbt's DDL — that regression must
+	// not come back.
+	if strings.Contains(clause, "query_kind") {
+		t.Errorf("hideSystemQueriesClause() = %q, should not filter by query_kind (hides user DDL like dbt)", clause)
 	}
 
 	// A user's own SELECT ... FROM system.* is real workload and must remain

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -292,6 +292,7 @@ export interface ProcessEntry {
   normalized_query_hash: string;
   query_kind: string;
   current_database: string;
+  log_comment: string;
   is_initial_query: number;
   initial_query_id: string;
 }

--- a/web/src/pages/RunningQueries.tsx
+++ b/web/src/pages/RunningQueries.tsx
@@ -20,7 +20,6 @@ import { ApiError } from "@/api/errors";
 import { useElapsedTimer } from "@/hooks/useElapsedTimer";
 
 const QUERY_KINDS = ["Select", "Insert", "Create", "Alter", "Drop", "Explain", "System", "Other"] as const;
-const INTERNAL_PREFIXES = ["SYSTEM", "KILL", "SET", "SHOW", "EXISTS", "USE"];
 
 function queryKind(query: string): string {
   const upper = query.trim().toUpperCase();
@@ -143,9 +142,10 @@ export function RunningQueries({ connected }: { connected: boolean }) {
         if (filterKind !== "Other" && kind !== filterKind) return false;
       }
       if (!showSystem) {
-        const upper = p.query.trim().toUpperCase();
-        if (INTERNAL_PREFIXES.some((p) => upper.startsWith(p))) return false;
-        if (p.query.includes("system.") || p.query.includes("INFORMATION_SCHEMA")) return false;
+        // "Internal" means only queries ClickLens itself issued (tagged with
+        // log_comment='clicklens'). Don't guess by query_kind or prefix — that
+        // hid real user workload like dbt's CREATE/DROP/ALTER.
+        if (p.log_comment === "clicklens") return false;
       }
       return true;
     });


### PR DESCRIPTION
## Problem

`hideSystemQueriesClause` filtered by BOTH `query_kind NOT IN (...)` AND `log_comment != 'clicklens'`. The `query_kind` half hid real user workload — notably **dbt**, which issues `CREATE`/`DROP`/`ALTER`/`TRUNCATE` as part of its normal workflow. Users had to toggle "Internal queries" to see their own DDL in the query log.

## Root cause

The codebase was guessing what "internal" means based on two different heuristics:

| Surface | Before | After |
|---|---|---|
| `hideSystemQueriesClause` (QueryList + QueryFingerprints) | `query_kind NOT IN (explain, system, show, create, drop, alter, …) AND log_comment != 'clicklens'` | `log_comment != 'clicklens'` |
| `RunningQueries` client-side filter | prefix match (`SYSTEM, KILL, SET, SHOW, EXISTS, USE`) + `system.`/`INFORMATION_SCHEMA` substring | `log_comment === 'clicklens'` |
| `GetQueryHealthTrend` | already `log_comment != 'clicklens'` only | (unchanged) |

ClickLens already stamps its own queries with `log_comment='clicklens'` (`internal/clickhouse/client.go:187`). That tag is the authoritative signal — the heuristics were redundant and wrong.

## Changes

**Backend**
- `internal/clickhouse/query_log.go` — `hideSystemQueriesClause` drops the `query_kind NOT IN (...)` half.
- `internal/clickhouse/processes.go` — expose `log_comment` on `ProcessEntry` + `processColumns` + `scanTargets()` so the Running Queries page can filter on it.

**Frontend**
- `web/src/api/types.ts` — add `log_comment: string` to `ProcessEntry`.
- `web/src/pages/RunningQueries.tsx` — delete `INTERNAL_PREFIXES`; the `showSystem` filter is now `log_comment === 'clicklens'`. `queryKind()` is kept (used by the Query Kind dropdown — that's an explicit user filter, not internal classification).

**Tests**
- `internal/clickhouse/query_log_test.go` — `TestHideSystemQueriesClause` now asserts `query_kind` is **not** in the clause (regression guard).
- `internal/clickhouse/processes_test.go` (new) — verifies `log_comment` is wired through `processColumns` and `scanTargets()`.

## Out of scope (intentionally)

- Hard-coded `query != 'SELECT 1'` noise filter (`query_log.go:128`) — kept, unrelated.
- URL param `hide_system_queries` and Go field `HideSystemQueries` — retained for back-compat with bookmarked URLs. UI label is already "Internal queries".
- User-facing "Query Kind" dropdown filter on both pages — untouched.
- Flag rename to `hide_internal_queries` — skipped to avoid URL breakage.

## Verification

```
make test-unit    # pass (incl. new + updated tests)
make lint         # 0 issues
cd web && npm run build  # tsc + vite OK
cd web && npm test       # 108 tests pass
```