### PR TITLE
fix(processes): read log_comment from Settings map

### DIFF
--- a/internal/clickhouse/processes.go
+++ b/internal/clickhouse/processes.go
@@ -24,9 +24,10 @@ type ProcessEntry struct {
 	NormalizedQueryHash string    `json:"normalized_query_hash"`
 	QueryKind           string    `json:"query_kind"`
 	Database            string    `json:"current_database"`
-	// LogComment is the value of the log_comment setting for this query.
-	// ClickLens stamps its own queries with managedLogComment; the frontend
-	// uses this (and only this) to identify internal queries.
+	// LogComment is the value of the log_comment setting for this query,
+	// read from the Settings map. ClickLens stamps its own queries with
+	// managedLogComment; the frontend uses this (and only this) to identify
+	// internal queries.
 	LogComment     string `json:"log_comment"`
 	IsInitialQuery uint8  `json:"is_initial_query"`
 	InitialQueryID string `json:"initial_query_id"`
@@ -36,6 +37,10 @@ type ProcessEntry struct {
 // ListProcesses and GetProcess so the two scans cannot drift. now()-elapsed
 // derives a start time (system.processes exposes only elapsed, not a native
 // start timestamp).
+//
+// system.processes has no native log_comment column, but the Settings Map
+// exposes every changed setting — `Settings['log_comment']` returns the tag
+// ClickLens stamps on its own queries (empty string for user queries).
 const processColumns = `query_id, query, user,
 	elapsed * 1000 AS query_duration_ms,
 	now() - elapsed AS query_start_time,
@@ -45,7 +50,7 @@ const processColumns = `query_id, query, user,
 	toString(normalized_query_hash) AS normalized_query_hash,
 	query_kind,
 	current_database,
-	log_comment,
+	Settings['log_comment'] AS log_comment,
 	is_initial_query, initial_query_id`
 
 func (p *ProcessEntry) scanTargets() []any {

--- a/internal/clickhouse/processes_test.go
+++ b/internal/clickhouse/processes_test.go
@@ -5,37 +5,41 @@ import (
 	"testing"
 )
 
-// TestProcessColumns_HasLogComment is a belt-and-suspenders check that
-// system.processes SELECTs surface log_comment so the frontend can identify
-// ClickLens's own queries (the sole signal for "internal").
-func TestProcessColumns_HasLogComment(t *testing.T) {
-	if !strings.Contains(processColumns, "log_comment") {
-		t.Errorf("processColumns = %q, expected to include log_comment", processColumns)
+// TestProcessColumns_ReadsLogCommentFromSettings is a belt-and-suspenders
+// check that the system.processes SELECT surfaces log_comment so the frontend
+// can identify ClickLens's own queries (the sole signal for "internal").
+//
+// system.processes has no native log_comment column, so the SELECT must read
+// it from the Settings map: `Settings['log_comment'] AS log_comment`.
+// Asserting both halves catches the regression that triggered PR #29 — the
+// original PR #28 queried `log_comment` directly and ClickHouse rejected it
+// with UNKNOWN_IDENTIFIER.
+func TestProcessColumns_ReadsLogCommentFromSettings(t *testing.T) {
+	if !strings.Contains(processColumns, "Settings['log_comment']") {
+		t.Errorf("processColumns = %q, expected to read Settings['log_comment']", processColumns)
+	}
+	if strings.Contains(processColumns, "current_database,\n\tlog_comment,") {
+		t.Errorf("processColumns must not select log_comment as a bare column — system.processes has no such column")
 	}
 }
 
-// TestProcessEntry_ScanTargets_LogComment makes sure the new LogComment field
-// is wired into scanTargets — otherwise the column would come back from
+// TestProcessEntry_ScanTargets_LogComment makes sure the LogComment field is
+// wired into scanTargets — otherwise the column would come back from
 // system.processes but never populate the struct, and the frontend filter
 // would never see "clicklens".
 func TestProcessEntry_ScanTargets_LogComment(t *testing.T) {
 	p := &ProcessEntry{}
 	targets := p.scanTargets()
 
-	// scanTargets returns a pointer per selected column. Mutate the field
-	// through the slice and confirm LogComment reflects it — that only
-	// works if the right pointer is in the slice.
 	logCommentValue := "clicklens"
-	for i, t := range targets {
+	for _, t := range targets {
 		if strPtr, ok := t.(*string); ok {
 			*strPtr = logCommentValue
 			if p.LogComment == logCommentValue {
 				return
 			}
-			// reset in case we picked the wrong *string on the way
 			*strPtr = ""
 		}
-		_ = i
 	}
 	t.Errorf("scanTargets() = %d entries, none pointed at &p.LogComment", len(targets))
 }


### PR DESCRIPTION
## Bug

Follow-up to PR #28, which broke the Running Queries page:

```
Code: 47. DB::Exception: Unknown expression identifier `log_comment` in scope
SELECT query_id, query, user, ..., current_database, log_comment, is_initial_query, ...
FROM clusterAllReplicas('dwh', system.processes) ORDER BY query_duration_ms DESC. (UNKNOWN_IDENTIFIER)
```

`system.processes` has no native `log_comment` column — only `system.query_log` does. PR #28 assumed parity between the two tables and the assumption was wrong.

## Fix

One-token change in `internal/clickhouse/processes.go`:

```diff
-  log_comment,
+  Settings['log_comment'] AS log_comment,
```

`system.processes` exposes the `Settings` column as a `Map(String, String)` of every changed setting. Reading `Settings['log_comment']` returns the tag ClickLens stamps on its own queries (`'clicklens'`) and an empty string for user queries. The frontend filter (`p.log_comment === 'clicklens'`) keeps working unchanged.

## Verification

Spun up `make dev-clickhouse` (CH 26.5) and tested against it end-to-end:

| Scenario | Result |
|---|---|
| Bare column `SELECT log_comment FROM system.processes` | `UNKNOWN_IDENTIFIER` (the bug) |
| `SELECT Settings['log_comment'] FROM system.processes` | ✅ returns empty / `clicklens` |
| Same query via `clusterAllReplicts('dev_cluster', system.processes)` | ✅ works (the user's failing path) |
| `GET /api/processes` from the actual backend | ✅ 200, `log_comment` field populated correctly |
| Tagged query in flight (log_comment='clicklens') | ✅ returns `'clicklens'` |
| Untagged query in flight (e.g. dbt / clickhouse-client) | ✅ returns `''` |
| Backend's own `SELECT FROM system.processes` | ✅ tagged `clicklens` by the driver — hidden by the filter |

## Test

`TestProcessColumns_ReadsLogCommentFromSettings` now asserts BOTH halves:
- MUST contain `Settings['log_comment']`
- MUST NOT contain a bare `log_comment` column

So this regression can't silently come back.

```
make test-unit    # pass
make lint         # 0 issues
cd web && npm run build  # OK
cd web && npm test       # 108 pass
```